### PR TITLE
feat: Add worldview grid toggle button

### DIFF
--- a/components/editors/GridToggleButton.tsx
+++ b/components/editors/GridToggleButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Button } from '../common/Button';
+import { GridIcon } from '../icons/MsxIcons';
+
+interface GridToggleButtonProps {
+  isGridVisible: boolean;
+  onToggle: () => void;
+}
+
+export const GridToggleButton: React.FC<GridToggleButtonProps> = ({ isGridVisible, onToggle }) => {
+  return (
+    <Button
+      onClick={onToggle}
+      size="sm"
+      variant={isGridVisible ? 'secondary' : 'ghost'}
+      title={isGridVisible ? 'Hide Grid' : 'Show Grid'}
+      icon={<GridIcon className="w-4 h-4" />}
+    >
+      Grid
+    </Button>
+  );
+};

--- a/components/editors/WorldGridOverlay.tsx
+++ b/components/editors/WorldGridOverlay.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+interface WorldGridOverlayProps {
+  worldWidth: number;
+  worldHeight: number;
+  screenWidth: number;
+  screenHeight: number;
+}
+
+export const WorldGridOverlay: React.FC<WorldGridOverlayProps> = ({
+  worldWidth,
+  worldHeight,
+  screenWidth,
+  screenHeight,
+}) => {
+  const patternId = "grid-pattern";
+
+  return (
+    <svg
+      width={worldWidth}
+      height={worldHeight}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: worldWidth,
+        height: worldHeight,
+        pointerEvents: 'none', // Make sure it doesn't interfere with mouse events
+      }}
+    >
+      <defs>
+        <pattern
+          id={patternId}
+          width={screenWidth}
+          height={screenHeight}
+          patternUnits="userSpaceOnUse"
+        >
+          <rect
+            width={screenWidth}
+            height={screenHeight}
+            fill="none"
+            stroke="rgba(128, 128, 128, 0.5)"
+            strokeWidth="1"
+            strokeDasharray="2,2"
+          />
+        </pattern>
+      </defs>
+
+      <rect width={worldWidth} height={worldHeight} fill={`url(#${patternId})`} />
+    </svg>
+  );
+};

--- a/components/editors/WorldViewEditor.tsx
+++ b/components/editors/WorldViewEditor.tsx
@@ -4,6 +4,8 @@ import { Panel } from '../common/Panel';
 import { WorldViewIcon, RefreshCwIcon } from '../icons/MsxIcons';
 import { EDITOR_BASE_TILE_DIM_S2, MSX1_PALETTE, MSX_SCREEN5_PALETTE, SCREEN2_PIXELS_PER_COLOR_SEGMENT } from '../../constants';
 import { Button } from '../common/Button';
+import { GridToggleButton } from './GridToggleButton';
+import { WorldGridOverlay } from './WorldGridOverlay';
 
 const SCREEN_EDITOR_BASE_TILE_DIM_OTHER = 16;
 
@@ -105,6 +107,7 @@ export const WorldViewEditor: React.FC<WorldViewEditorProps> = ({
   currentScreenMode
 }) => {
     const [selectedWorldMapId, setSelectedWorldMapId] = useState<string | null>(null);
+    const [isGridVisible, setIsGridVisible] = useState(false);
     const [zoom, setZoom] = useState(1);
     const [pan, setPan] = useState({ x: 0, y: 0 });
     const [isPanning, setIsPanning] = useState(false);
@@ -112,6 +115,8 @@ export const WorldViewEditor: React.FC<WorldViewEditorProps> = ({
     const containerRef = useRef<HTMLDivElement>(null);
     const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
     const [refreshKey, setRefreshKey] = useState(0);
+
+    const handleToggleGrid = () => setIsGridVisible(prevState => !prevState);
 
     const EDITOR_BASE_TILE_DIM = currentScreenMode === "SCREEN 2 (Graphics I)" 
         ? EDITOR_BASE_TILE_DIM_S2 
@@ -357,6 +362,7 @@ export const WorldViewEditor: React.FC<WorldViewEditorProps> = ({
                     ))}
                 </select>
                 <div className="flex-grow"></div>
+                <GridToggleButton isGridVisible={isGridVisible} onToggle={handleToggleGrid} />
                 <Button 
                     onClick={() => setRefreshKey(k => k + 1)} 
                     size="sm" 
@@ -385,6 +391,14 @@ export const WorldViewEditor: React.FC<WorldViewEditorProps> = ({
                             transformOrigin: '0 0'
                         }}
                     >
+                        {isGridVisible && (
+                            <WorldGridOverlay
+                                worldWidth={screensToRender.worldBounds.width}
+                                worldHeight={screensToRender.worldBounds.height}
+                                screenWidth={256}
+                                screenHeight={212}
+                            />
+                        )}
                         {screensToRender.nodes.map(s => (
                             <div
                                 key={s.key}

--- a/components/icons/MsxIcons.tsx
+++ b/components/icons/MsxIcons.tsx
@@ -6,6 +6,16 @@ interface IconProps {
   className?: string;
 }
 
+export const GridIcon: React.FC<IconProps> = ({ className }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+    <rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect>
+    <line x1="3" x2="21" y1="9" y2="9"></line>
+    <line x1="3" x2="21" y1="15" y2="15"></line>
+    <line x1="9" x2="9" y1="3" y2="21"></line>
+    <line x1="15" x2="15" y1="3" y2="21"></line>
+  </svg>
+);
+
 export const SphereIcon: React.FC<IconProps> = ({ className }) => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className={`w-5 h-5 ${className}`}>
     <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16z" clipRule="evenodd" />


### PR DESCRIPTION
Implements a toggle button in the Worldview editor's toolbar to show or hide a grid overlay on the world map.

- Creates a new `GridToggleButton` component to handle the UI for the toggle.
- Creates a new `WorldGridOverlay` component that renders an efficient SVG-based grid.
- Adds a `GridIcon` to `MsxIcons.tsx`.
- Modifies `WorldViewEditor.tsx` to include state management for the grid's visibility and conditionally renders the overlay.