### PR TITLE
feat: Add worldview grid toggle button

### DIFF
--- a/components/editors/WorldGridOverlay.tsx
+++ b/components/editors/WorldGridOverlay.tsx
@@ -39,9 +39,17 @@ export const WorldGridOverlay: React.FC<WorldGridOverlayProps> = ({
             width={screenWidth}
             height={screenHeight}
             fill="none"
-            stroke="rgba(128, 128, 128, 0.5)"
+            stroke="rgba(0, 0, 0, 0.7)"
+            strokeWidth="2"
+            strokeDasharray="2,3"
+          />
+          <rect
+            width={screenWidth}
+            height={screenHeight}
+            fill="none"
+            stroke="rgba(255, 255, 255, 0.8)"
             strokeWidth="1"
-            strokeDasharray="2,2"
+            strokeDasharray="2,3"
           />
         </pattern>
       </defs>

--- a/components/editors/WorldViewEditor.tsx
+++ b/components/editors/WorldViewEditor.tsx
@@ -392,12 +392,21 @@ export const WorldViewEditor: React.FC<WorldViewEditorProps> = ({
                         }}
                     >
                         {isGridVisible && (
-                            <WorldGridOverlay
-                                worldWidth={screensToRender.worldBounds.width}
-                                worldHeight={screensToRender.worldBounds.height}
-                                screenWidth={256}
-                                screenHeight={212}
-                            />
+                            <div
+                                style={{
+                                    position: 'absolute',
+                                    left: screensToRender.worldBounds.minX,
+                                    top: screensToRender.worldBounds.minY,
+                                    pointerEvents: 'none'
+                                }}
+                            >
+                                <WorldGridOverlay
+                                    worldWidth={screensToRender.worldBounds.width}
+                                    worldHeight={screensToRender.worldBounds.height}
+                                    screenWidth={256}
+                                    screenHeight={212}
+                                />
+                            </div>
                         )}
                         {screensToRender.nodes.map(s => (
                             <div


### PR DESCRIPTION
Implements a toggle button in the Worldview editor's toolbar to show or hide a grid overlay on the world map.

- Creates a new `GridToggleButton` component to handle the UI for the toggle.
- Creates a new `WorldGridOverlay` component that renders an efficient SVG-based grid.
- Adds a `GridIcon` to `MsxIcons.tsx`.
- Modifies `WorldViewEditor.tsx` to include state management for the grid's visibility and conditionally renders the overlay.

fix: Address feedback on grid visibility and alignment

- Updates the `WorldGridOverlay` to use a high-contrast, outlined stroke for better visibility on all backgrounds.
- Adjusts the positioning of the `WorldGridOverlay` within `WorldViewEditor` to ensure it correctly aligns with the world map coordinates.