### PR TITLE
feat: Add worldview grid toggle button

### DIFF
--- a/components/editors/WorldViewEditor.tsx
+++ b/components/editors/WorldViewEditor.tsx
@@ -395,8 +395,8 @@ export const WorldViewEditor: React.FC<WorldViewEditorProps> = ({
                             <div
                                 style={{
                                     position: 'absolute',
-                                    left: screensToRender.worldBounds.minX,
-                                    top: screensToRender.worldBounds.minY,
+                                    left: screensToRender.worldBounds.minX - 48,
+                                    top: screensToRender.worldBounds.minY + 8,
                                     pointerEvents: 'none'
                                 }}
                             >


### PR DESCRIPTION
Implements a toggle button in the Worldview editor's toolbar to show or hide a grid overlay on the world map.

- Creates a new `GridToggleButton` component to handle the UI for the toggle.
- Creates a new `WorldGridOverlay` component that renders an efficient SVG-based grid.
- Adds a `GridIcon` to `MsxIcons.tsx`.
- Modifies `WorldViewEditor.tsx` to include state management for the grid's visibility and conditionally renders the overlay.

fix: Address feedback on grid visibility and alignment

- Updates the `WorldGridOverlay` to use a high-contrast, outlined stroke for better visibility on all backgrounds.
- Adjusts the positioning of the `WorldGridOverlay` within `WorldViewEditor` to ensure it correctly aligns with the world map coordinates.

fix: Apply specific offsets to grid position

- Applies a final positional adjustment to the grid overlay based on user feedback (-48px left, +8px top) to ensure perfect alignment.