### PR TITLE
fix(ScreenEditor): Disable text selection

### DIFF
--- a/components/editors/ScreenEditor.tsx
+++ b/components/editors/ScreenEditor.tsx
@@ -650,7 +650,7 @@ export const ScreenEditor: React.FC<ScreenEditorProps> = ({
   };
 
   return (
-    <Panel title={`Screen Editor: ${screenMap.name} ${currentScreenMode === "SCREEN 2 (Graphics I)" ? `(Base ${EDITOR_BASE_TILE_DIM}x${EDITOR_BASE_TILE_DIM})` : `(Base ${EDITOR_BASE_TILE_DIM}x${EDITOR_BASE_TILE_DIM})`}`} className="flex-grow flex flex-col bg-msx-bgcolor overflow-hidden">
+    <Panel title={`Screen Editor: ${screenMap.name} ${currentScreenMode === "SCREEN 2 (Graphics I)" ? `(Base ${EDITOR_BASE_TILE_DIM}x${EDITOR_BASE_TILE_DIM})` : `(Base ${EDITOR_BASE_TILE_DIM}x${EDITOR_BASE_TILE_DIM})`}`} className="flex-grow flex flex-col bg-msx-bgcolor overflow-hidden select-none">
       <ScreenEditorToolbar
         activeLayer={activeLayer}
         onLayerChange={handleLayerChange}


### PR DESCRIPTION
Disables text selection and dragging in the Screen Editor component by adding the `select-none` Tailwind CSS utility class.

This prevents the browser's default text selection behavior from interfering with the application's built-in area selection feature in the Mideas app.