### PR TITLE
feat: Add 'Last Editor' button to toolbar

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -42,7 +42,10 @@ const SNIPPETS_STORAGE_KEY = 'msxIdeUserSnippets_v1';
 const AUTOSAVE_INTERVAL = 10 * 60 * 1000;
 
 const App: React.FC = () => {
-  const [currentEditor, setCurrentEditor] = useState<EditorType>(EditorType.None); 
+  const [currentEditor, setCurrentEditor] = useState<EditorType>(EditorType.None);
+  const [previousEditorContext, setPreviousEditorContext] = useState<{ editor: EditorType, assetId: string | null } | null>(null);
+  const prevValuesRef = useRef<{ editor: EditorType, assetId: string | null }>();
+
   const [assets, setAssets] = useState<ProjectAsset[]>([]);
   const [selectedAssetId, setSelectedAssetId] = useState<string | null>(null);
   const [currentProjectName, setCurrentProjectName] = useState<string | null>(null); 
@@ -1126,9 +1129,27 @@ const App: React.FC = () => {
     }
   }, [entityTemplates, componentDefinitions, assets, setAssetsWithHistory, memoizedHandleSelectAsset]);
 
+  useEffect(() => {
+    if (prevValuesRef.current && prevValuesRef.current.editor !== currentEditor) {
+      setPreviousEditorContext(prevValuesRef.current);
+    }
+    prevValuesRef.current = { editor: currentEditor, assetId: selectedAssetId };
+  }, [currentEditor, selectedAssetId]);
+
+  const handleToggleEditor = useCallback(() => {
+    if (previousEditorContext) {
+      const newPreviousContext = { editor: currentEditor, assetId: selectedAssetId };
+      setCurrentEditor(previousEditorContext.editor);
+      setSelectedAssetId(previousEditorContext.assetId);
+      setPreviousEditorContext(newPreviousContext);
+    }
+  }, [previousEditorContext, currentEditor, selectedAssetId]);
+
   const allPassedProps = {
     currentEditor, setCurrentEditor, assets, setAssets, selectedAssetId, setSelectedAssetId, currentProjectName, setCurrentProjectName, currentScreenMode, setCurrentScreenMode, statusBarMessage, setStatusBarMessage, selectedColor, setSelectedColor, screenEditorSelectedTileId, setScreenEditorSelectedTileId, currentScreenEditorActiveLayer, setCurrentScreenEditorActiveLayer, componentDefinitions, setComponentDefinitions, entityTemplates, setEntityTemplates, currentEntityTypeToPlace, setCurrentEntityTypeToPlace, selectedEntityInstanceId, setSelectedEntityInstanceId, selectedEffectZoneId, setSelectedEffectZoneId, isRenameModalOpen, setIsRenameModalOpen, assetToRenameInfo, setAssetToRenameInfo, isSaveAsModalOpen, setIsSaveAsModalOpen, isNewProjectModalOpen, setIsNewProjectModalOpen, isAboutModalOpen, setIsAboutModalOpen, isConfirmModalOpen, setIsConfirmModalOpen, confirmModalProps, setConfirmModalProps, tileBanks, setTileBanks, msxFont, setMsxFont, msxFontColorAttributes, setMsxFontColorAttributes, currentLoadedFontName, setCurrentLoadedFontName, helpDocsData, setHelpDocsData, dataOutputFormat, setDataOutputFormat, autosaveEnabled, setAutosaveEnabled, snippetsEnabled, setSnippetsEnabled, syntaxHighlightingEnabled, setSyntaxHighlightingEnabled, isConfigModalOpen, setIsConfigModalOpen, isSpriteSheetModalOpen, setIsSpriteSheetModalOpen, isSpriteFramesModalOpen, setIsSpriteFramesModalOpen, spriteForFramesModal, setSpriteForFramesModal, snippetToInsert, setSnippetToInsert, userSnippets, setUserSnippets, isSnippetEditorModalOpen, setIsSnippetEditorModalOpen, editingSnippet, setEditingSnippet, isAutosaving, setIsAutosaving, history, setHistory, copiedScreenBuffer, setCopiedScreenBuffer, copiedTileData, setCopiedTileData, copiedLayerBuffer, setCopiedLayerBuffer, contextMenu, setContextMenu, waypointPickerState, setWaypointPickerState, mainMenuConfig, onUpdateMainMenuConfig: setMainMenuConfig, handleUpdateSpriteOrder, handleOpenSpriteFramesModal, handleSplitFrames, handleCreateSpriteFromFrame, handleWaypointPicked, showContextMenu, closeContextMenu, playAutosaveSound, pushToHistory, clearAllHistory, setAssetsWithHistory, handleUpdateAsset, handleOpenSnippetEditor, handleSaveSnippet, handleDeleteSnippet, handleSnippetSelected, saveIdeConfig, resetIdeConfig, handleOpenNewProjectModal, handleConfirmNewProject, handleNewAsset, handleSpriteImported, memoizedHandleSelectAsset, memoizedOnRequestRename, handleConfirmRename, handleCancelRename, handleDeleteAsset, handleUpdateScreenMode, handleOpenSaveAsModal, handleSaveProject, handleConfirmSaveAsProjectAs, handleLoadProject, fileLoadInputRef, handleDeleteEntityInstance, handleShowMapFile, handleUndo, handleRedo, handleExportAllCodeFiles, handleCopyTileData, handleGenerateTemplatesAsm,
     isCompressDataModalOpen, setIsCompressDataModalOpen,
+    isToggleEditorDisabled: previousEditorContext === null,
+    onToggleEditor: handleToggleEditor,
   };
 
   return (

--- a/components/AppUI.tsx
+++ b/components/AppUI.tsx
@@ -180,6 +180,8 @@ interface AppUIProps {
   handleExportAllCodeFiles: () => void;
   handleCopyTileData: (tileToCopy: Tile) => void;
   handleGenerateTemplatesAsm: () => void;
+  isToggleEditorDisabled: boolean;
+  onToggleEditor: () => void;
 }
 
 
@@ -187,7 +189,8 @@ export const AppUI: React.FC<AppUIProps> = (props) => {
     const {
         currentEditor, assets, selectedAssetId, currentProjectName, currentScreenMode, statusBarMessage, selectedColor, screenEditorSelectedTileId, currentScreenEditorActiveLayer, componentDefinitions, entityTemplates, mainMenuConfig, currentEntityTypeToPlace, selectedEntityInstanceId, selectedEffectZoneId, isRenameModalOpen, assetToRenameInfo, isSaveAsModalOpen, isNewProjectModalOpen, isAboutModalOpen, isCompressDataModalOpen, isConfirmModalOpen, confirmModalProps, tileBanks, msxFont, msxFontColorAttributes, currentLoadedFontName, helpDocsData, dataOutputFormat, autosaveEnabled, snippetsEnabled, syntaxHighlightingEnabled, isConfigModalOpen, isSpriteSheetModalOpen, isSpriteFramesModalOpen, spriteForFramesModal, snippetToInsert, userSnippets, isSnippetEditorModalOpen, editingSnippet, isAutosaving, history, copiedScreenBuffer, copiedTileData, copiedLayerBuffer, contextMenu, waypointPickerState,
         
-        setCurrentEditor, setSelectedAssetId, setStatusBarMessage, setSelectedColor, setScreenEditorSelectedTileId, setCurrentScreenEditorActiveLayer, setCurrentEntityTypeToPlace, setSelectedEntityInstanceId, setSelectedEffectZoneId, setIsRenameModalOpen, setAssetToRenameInfo, setIsSaveAsModalOpen, setIsNewProjectModalOpen, setIsAboutModalOpen, setIsCompressDataModalOpen, setIsConfirmModalOpen, setConfirmModalProps, setComponentDefinitions, setEntityTemplates, onUpdateMainMenuConfig, setTileBanks, setMsxFont, setMsxFontColorAttributes, setDataOutputFormat, setAutosaveEnabled, setIsConfigModalOpen, setIsSpriteSheetModalOpen, setIsSpriteFramesModalOpen, setSpriteForFramesModal, setUserSnippets, setIsSnippetEditorModalOpen, setEditingSnippet, setCopiedScreenBuffer, setCopiedLayerBuffer, setContextMenu, setWaypointPickerState, handleUpdateSpriteOrder, handleOpenSpriteFramesModal, handleSplitFrames, handleCreateSpriteFromFrame, handleWaypointPicked, showContextMenu, closeContextMenu, setAssetsWithHistory, handleUpdateAsset, handleOpenSnippetEditor, handleSaveSnippet, handleDeleteSnippet, handleSnippetSelected, saveIdeConfig, resetIdeConfig, handleOpenNewProjectModal, handleConfirmNewProject, handleNewAsset, handleSpriteImported, memoizedHandleSelectAsset, memoizedOnRequestRename, handleConfirmRename, handleCancelRename, handleDeleteAsset, handleOpenSaveAsModal, handleSaveProject, handleConfirmSaveAsProjectAs, handleLoadProject, fileLoadInputRef, handleDeleteEntityInstance, handleShowMapFile, handleUndo, handleRedo, handleExportAllCodeFiles, handleCopyTileData, handleGenerateTemplatesAsm
+        setCurrentEditor, setSelectedAssetId, setStatusBarMessage, setSelectedColor, setScreenEditorSelectedTileId, setCurrentScreenEditorActiveLayer, setCurrentEntityTypeToPlace, setSelectedEntityInstanceId, setSelectedEffectZoneId, setIsRenameModalOpen, setAssetToRenameInfo, setIsSaveAsModalOpen, setIsNewProjectModalOpen, setIsAboutModalOpen, setIsCompressDataModalOpen, setIsConfirmModalOpen, setConfirmModalProps, setComponentDefinitions, setEntityTemplates, onUpdateMainMenuConfig, setTileBanks, setMsxFont, setMsxFontColorAttributes, setDataOutputFormat, setAutosaveEnabled, setIsConfigModalOpen, setIsSpriteSheetModalOpen, setIsSpriteFramesModalOpen, setSpriteForFramesModal, setUserSnippets, setIsSnippetEditorModalOpen, setEditingSnippet, setCopiedScreenBuffer, setCopiedLayerBuffer, setContextMenu, setWaypointPickerState, handleUpdateSpriteOrder, handleOpenSpriteFramesModal, handleSplitFrames, handleCreateSpriteFromFrame, handleWaypointPicked, showContextMenu, closeContextMenu, setAssetsWithHistory, handleUpdateAsset, handleOpenSnippetEditor, handleSaveSnippet, handleDeleteSnippet, handleSnippetSelected, saveIdeConfig, resetIdeConfig, handleOpenNewProjectModal, handleConfirmNewProject, handleNewAsset, handleSpriteImported, memoizedHandleSelectAsset, memoizedOnRequestRename, handleConfirmRename, handleCancelRename, handleDeleteAsset, handleOpenSaveAsModal, handleSaveProject, handleConfirmSaveAsProjectAs, handleLoadProject, fileLoadInputRef, handleDeleteEntityInstance, handleShowMapFile, handleUndo, handleRedo, handleExportAllCodeFiles, handleCopyTileData, handleGenerateTemplatesAsm,
+        isToggleEditorDisabled, onToggleEditor
     } = props;
 
   const activeAsset = assets.find(a => a.id === selectedAssetId);
@@ -316,6 +319,8 @@ export const AppUI: React.FC<AppUIProps> = (props) => {
         onCompressExportCompileRun={() => setStatusBarMessage("Compress, Export, Compile, Run: Mock Action")}
         onConfigureASM={() => alert("Configure ASM Compiler: Mock Action")}
         onConfigureEmulator={() => alert("Configure MSX Emulator: Mock Action")}
+        onToggleEditor={onToggleEditor}
+        isToggleEditorDisabled={isToggleEditorDisabled}
       />
       <input type="file" accept=".json" ref={fileLoadInputRef} onChange={handleLoadProject} style={{ display: 'none' }} />
 

--- a/components/layout/Toolbar.tsx
+++ b/components/layout/Toolbar.tsx
@@ -4,7 +4,7 @@ import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useTheme } from '../../contexts/ThemeContext';
 import { Button } from '../common/Button';
 import { ProjectAsset, DataFormat, EditorType } from '../../types'; 
-import { SaveFloppyIcon, FolderOpenIcon, PlayIcon, CogIcon, PlusCircleIcon, QuestionMarkCircleIcon, ArrowUturnLeftIcon, ArrowUturnRightIcon, PuzzlePieceIcon, TilesetIcon, SpriteIcon, MapIcon, WorldMapIcon, SoundIcon, MusicNoteIcon, CodeIcon, BugIcon } from '../icons/MsxIcons';
+import { SaveFloppyIcon, FolderOpenIcon, PlayIcon, CogIcon, PlusCircleIcon, QuestionMarkCircleIcon, ArrowUturnLeftIcon, ArrowUturnRightIcon, PuzzlePieceIcon, TilesetIcon, SpriteIcon, MapIcon, WorldMapIcon, SoundIcon, MusicNoteIcon, CodeIcon, BugIcon, SwapHorizIcon } from '../icons/MsxIcons';
 
 // --- PROPS INTERFACE ---
 interface ToolbarProps {
@@ -38,6 +38,8 @@ interface ToolbarProps {
   onCompressExportCompileRun: () => void;
   onConfigureASM: () => void;
   onConfigureEmulator: () => void;
+  onToggleEditor: () => void;
+  isToggleEditorDisabled: boolean;
 }
 
 // --- REUSABLE DROPDOWN COMPONENTS ---
@@ -123,7 +125,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   autosaveEnabled, setAutosaveEnabled, onSaveConfig, onResetConfig, isAutosaving,
   onUndo, onRedo, isUndoDisabled, isRedoDisabled, onOpenAbout,
   onOpenComponentDefEditor, onOpenEntityTemplateEditor, onCompressAllDataFiles,
-  onCompileAndRun, onCompressExportCompileRun, onConfigureASM, onConfigureEmulator
+  onCompileAndRun, onCompressExportCompileRun, onConfigureASM, onConfigureEmulator,
+  onToggleEditor, isToggleEditorDisabled
 }) => {
     const { loadConfig: loadThemeConfig } = useTheme();
 
@@ -217,6 +220,17 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         <DropdownItem onClick={onOpenHelpDocs} icon={<QuestionMarkCircleIcon/>}>Tutorials</DropdownItem>
         <DropdownItem onClick={onOpenAbout}>About</DropdownItem>
       </DropdownMenu>
+
+      <Button
+        onClick={onToggleEditor}
+        variant="ghost"
+        size="sm"
+        icon={<SwapHorizIcon />}
+        title="Toggle Last Editor"
+        disabled={isToggleEditorDisabled}
+      >
+        Last Editor
+      </Button>
       
       <div className="flex-grow"></div>
       


### PR DESCRIPTION
This commit introduces a new 'Last Editor' button in the main toolbar, next to the 'Help' menu.

This button allows the user to quickly toggle between the current and the previously active editor, similar to the 'last channel' button on a TV remote.

To achieve this, the application now tracks the previous editor context, including both the editor type and the selected asset ID. This ensures that the correct asset is displayed when toggling back to a previous editor.