### PR TITLE
feat(boss-editor): Add zoom functionality to the grid

### DIFF
--- a/components/editors/BossEditor.tsx
+++ b/components/editors/BossEditor.tsx
@@ -52,6 +52,7 @@ export const BossEditor: React.FC<BossEditorProps> = ({ boss, onUpdate, allAsset
     const [selectedPhaseId, setSelectedPhaseId] = useState<string | null>(boss.phases[0]?.id || null);
     const [editMode, setEditMode] = useState<BossEditMode>('tiles');
     const [selectedTileId, setSelectedTileId] = useState<string | null>(null);
+    const [zoom, setZoom] = useState(1);
     
     const [assetPickerState, setAssetPickerState] = useState<{
         isOpen: boolean; assetTypeToPick: ProjectAsset['type'] | null;
@@ -266,6 +267,7 @@ export const BossEditor: React.FC<BossEditorProps> = ({ boss, onUpdate, allAsset
                             editMode={editMode}
                             onGridClick={handleGridClick}
                             onGridContextMenu={handleGridContextMenu}
+                            zoom={zoom}
                         />
                     ) : selectedPhase && selectedPhase.buildType === 'sprite' ? (
                         <div className="flex flex-col items-center space-y-2">
@@ -330,6 +332,20 @@ export const BossEditor: React.FC<BossEditorProps> = ({ boss, onUpdate, allAsset
                                     <Button onClick={() => setEditMode('tiles')} variant={editMode === 'tiles' ? 'secondary' : 'ghost'} size="sm">Graphic</Button>
                                     <Button onClick={() => setEditMode('collision')} variant={editMode === 'collision' ? 'secondary' : 'ghost'} size="sm">Collision</Button>
                                     <Button onClick={() => setEditMode('weakpoints')} variant={editMode === 'weakpoints' ? 'secondary' : 'ghost'} size="sm">Weak Points</Button>
+                                </div>
+                                <div className="flex items-center space-x-2 pt-2 border-t border-msx-border/30">
+                                    <label htmlFor="boss-zoom" className="text-msx-textsecondary text-xs whitespace-nowrap">Zoom:</label>
+                                    <input
+                                        id="boss-zoom"
+                                        type="range"
+                                        min="0.5"
+                                        max="4"
+                                        step="0.1"
+                                        value={zoom}
+                                        onChange={e => setZoom(parseFloat(e.target.value))}
+                                        className="w-full h-2 bg-msx-border rounded-lg appearance-none cursor-pointer"
+                                    />
+                                    <span className="text-xs w-10 text-right font-mono">{zoom.toFixed(1)}x</span>
                                 </div>
                             </div>
                         ) : <p className="text-xs text-msx-textsecondary italic">Select a phase to see properties.</p>}

--- a/components/editors/BossMovementController.tsx
+++ b/components/editors/BossMovementController.tsx
@@ -10,6 +10,7 @@ interface BossMovementControllerProps {
     editMode: BossEditMode;
     onGridClick: (x: number, y: number) => void;
     onGridContextMenu: (event: React.MouseEvent, x: number, y: number) => void;
+    zoom: number;
 }
 
 export const BossMovementController: React.FC<BossMovementControllerProps> = ({
@@ -17,7 +18,8 @@ export const BossMovementController: React.FC<BossMovementControllerProps> = ({
     tileset,
     editMode,
     onGridClick,
-    onGridContextMenu
+    onGridContextMenu,
+    zoom = 1,
 }) => {
     if (!phase || !phase.dimensions) {
         return <div className="p-4 text-msx-textsecondary">No phase selected or phase has no dimensions.</div>;
@@ -27,7 +29,14 @@ export const BossMovementController: React.FC<BossMovementControllerProps> = ({
 
     return (
         <div className="flex flex-col items-center space-y-2" style={{ userSelect: 'none' }}>
-            <div className="aspect-square bg-msx-bgcolor border border-msx-border rounded-md overflow-auto p-1" style={{ width: 'min-content' }}>
+            <div
+                className="aspect-square bg-msx-bgcolor border border-msx-border rounded-md overflow-auto p-1"
+                style={{
+                    width: 'min-content',
+                    transform: `scale(${zoom})`,
+                    transformOrigin: 'top left'
+                }}
+            >
                 <div className="grid" style={{ gridTemplateColumns: `repeat(${width}, 32px)` }}>
                     {Array.from({ length: height * width }).map((_, i) => {
                         const x = i % width;

--- a/components/modals/AboutModal.tsx
+++ b/components/modals/AboutModal.tsx
@@ -27,7 +27,7 @@ export const AboutModal: React.FC<AboutModalProps> = ({ isOpen, onClose }) => {
         </h2>
         <div className="space-y-2 text-sm text-msx-textprimary mb-6 font-sans">
             <p>A specialized Integrated Development Environment for MSX (MSX1/MSX2) game development.</p>
-            <p>Version: 1.03 (Conceptual Mockup)</p>
+            <p>Version: 1.04 (Conceptual Mockup)</p>
             <p>This tool showcases key UI/UX elements for retro game creation.</p>
         </div>
         <div className="flex justify-center">


### PR DESCRIPTION
- Adds a zoom slider to the `BossEditor` properties panel, allowing the user to scale the main grid.
- The zoom level is managed by a new state variable within the editor.
- The `BossMovementController` has been updated to accept and apply the zoom level.
- Also increments the version in the About modal to 1.04.