### PR TITLE
fix(boss-editor): Adjust grid layout and scrolling

### DIFF
--- a/components/editors/BossEditor.tsx
+++ b/components/editors/BossEditor.tsx
@@ -285,7 +285,7 @@ export const BossEditor: React.FC<BossEditorProps> = ({ boss, onUpdate, allAsset
     return (
         <Panel title={`Boss Editor: ${boss.name}`} className="flex-grow flex flex-col !p-0">
             <div className="flex flex-grow overflow-hidden" style={{ userSelect: 'none' }}>
-                <div className="flex-grow p-3 flex items-start justify-center">
+                <div className="flex-grow p-3 flex items-start justify-start overflow-auto">
                     {selectedPhase && selectedPhase.buildType === 'tile' ? (
                         <BossMovementController
                             phase={selectedPhase}


### PR DESCRIPTION
- Anchors the `BossEditor` grid to the top-left corner by changing flexbox alignment from `justify-center` to `justify-start`.
- Adds `overflow-auto` to the grid container to enable scrollbars when the zoomed content exceeds the available space.