### PR TITLE
feat: Link Boss to screen for preview and update version

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -613,6 +613,7 @@ const App: React.FC = () => {
             phases: [defaultPhase],
             phasesEnabled: [true],
             attacks: [],
+            linkedScreenId: null,
         } as Boss;
         newEditorType = EditorType.Boss;
         break;

--- a/components/editors/BossEditor.tsx
+++ b/components/editors/BossEditor.tsx
@@ -328,6 +328,21 @@ export const BossEditor: React.FC<BossEditorProps> = ({ boss, onUpdate, allAsset
                                 <label className="block text-msx-textsecondary">Total Health:</label>
                                 <input type="number" value={boss.totalHealth} onChange={e => handleUpdateField('totalHealth', parseInt(e.target.value) || 0)} min="1" className="w-full p-1 bg-msx-bgcolor border-msx-border rounded"/>
                             </div>
+                            <div>
+                                <label className="block text-msx-textsecondary mt-2">Preview Screen:</label>
+                                <select
+                                    value={boss.linkedScreenId || ''}
+                                    onChange={e => handleUpdateField('linkedScreenId', e.target.value || null)}
+                                    className="w-full p-1 bg-msx-bgcolor border-msx-border rounded"
+                                >
+                                    <option value="">None</option>
+                                    {allAssets.filter(a => a.type === 'screenmap').map(screen => (
+                                        <option key={screen.id} value={screen.id}>
+                                            {screen.name}
+                                        </option>
+                                    ))}
+                                </select>
+                            </div>
                         </div>
                     </Panel>
                     <Panel title="Phase / Movement Properties">
@@ -437,6 +452,7 @@ export const BossEditor: React.FC<BossEditorProps> = ({ boss, onUpdate, allAsset
                     onClose={() => setIsPreviewOpen(false)}
                     boss={boss}
                     tileset={tileset}
+                    allAssets={allAssets}
                 />
             )}
         </Panel>

--- a/components/modals/AboutModal.tsx
+++ b/components/modals/AboutModal.tsx
@@ -27,7 +27,7 @@ export const AboutModal: React.FC<AboutModalProps> = ({ isOpen, onClose }) => {
         </h2>
         <div className="space-y-2 text-sm text-msx-textprimary mb-6 font-sans">
             <p>A specialized Integrated Development Environment for MSX (MSX1/MSX2) game development.</p>
-            <p>Version: 1.11 (Conceptual Mockup)</p>
+            <p>Version: 1.12 (Conceptual Mockup)</p>
             <p>This tool showcases key UI/UX elements for retro game creation.</p>
         </div>
         <div className="flex justify-center">

--- a/components/modals/BossPreviewModal.tsx
+++ b/components/modals/BossPreviewModal.tsx
@@ -1,14 +1,15 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { Boss, Tile, MSXColorValue } from '../../types';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
+import { Boss, Tile, MSXColor, ProjectAsset, ScreenMap } from '../../types';
 import { Button } from '../common/Button';
-import { createTileDataURL } from '../utils/screenUtils';
-import { MSX_SCREEN5_PALETTE } from '../../constants';
+import { createTileDataURL, renderScreenToCanvas } from '../utils/screenUtils';
+import { MSX_SCREEN5_PALETTE, EDITOR_BASE_TILE_DIM_S2 } from '../../constants';
 
 interface BossPreviewModalProps {
     isOpen: boolean;
     onClose: () => void;
     boss: Boss;
     tileset: Tile[];
+    allAssets: ProjectAsset[]; // Now receiving all assets
 }
 
 const Modal: React.FC<{isOpen: boolean, onClose: () => void, title: string, children: React.ReactNode}> = ({isOpen, onClose, title, children}) => {
@@ -24,29 +25,50 @@ const Modal: React.FC<{isOpen: boolean, onClose: () => void, title: string, chil
     );
 }
 
-
-export const BossPreviewModal: React.FC<BossPreviewModalProps> = ({ isOpen, onClose, boss, tileset }) => {
+export const BossPreviewModal: React.FC<BossPreviewModalProps> = ({ isOpen, onClose, boss, tileset, allAssets }) => {
     const [frameDelay, setFrameDelay] = useState(200);
     const [currentPhaseIndex, setCurrentPhaseIndex] = useState(0);
+    const backgroundCanvasRef = useRef<HTMLCanvasElement>(null);
+
+    const linkedScreenAsset = useMemo(() => {
+        if (!boss.linkedScreenId) return null;
+        return allAssets.find(a => a.id === boss.linkedScreenId && a.type === 'screenmap');
+    }, [boss.linkedScreenId, allAssets]);
+
+    const fullTileset = useMemo(() => allAssets.filter(a => a.type === 'tile').map(a => a.data as Tile), [allAssets]);
 
     const enabledPhases = useMemo(() => {
         const phasesEnabled = boss.phasesEnabled ?? Array(boss.phases.length).fill(true);
         const enabled = boss.phases.filter((_, index) => phasesEnabled[index]);
-        return enabled.length > 0 ? enabled : boss.phases; // If no phases are enabled, show all as a fallback
+        return enabled.length > 0 ? enabled : boss.phases;
     }, [boss.phases, boss.phasesEnabled]);
 
     useEffect(() => {
-        if (!isOpen || enabledPhases.length === 0) {
+        if (!isOpen) return;
+
+        // Render background screen if linked
+        const canvas = backgroundCanvasRef.current;
+        const ctx = canvas?.getContext('2d');
+        if (ctx && linkedScreenAsset) {
+            const screenMap = linkedScreenAsset.data as ScreenMap;
+            // Assuming SCREEN 2 for now, as renderScreenToCanvas needs a specific mode
+            renderScreenToCanvas(canvas, screenMap, fullTileset, "SCREEN 2 (Graphics I)", EDITOR_BASE_TILE_DIM_S2);
+        } else if (ctx) {
+            // Clear canvas if no screen is linked
+            ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+        }
+
+        // Handle boss animation
+        if (enabledPhases.length === 0) {
             setCurrentPhaseIndex(0);
             return;
         }
-
         const timer = setTimeout(() => {
             setCurrentPhaseIndex((prevIndex) => (prevIndex + 1) % enabledPhases.length);
         }, frameDelay);
 
         return () => clearTimeout(timer);
-    }, [isOpen, currentPhaseIndex, frameDelay, enabledPhases]);
+    }, [isOpen, currentPhaseIndex, frameDelay, enabledPhases, linkedScreenAsset, fullTileset]);
 
     if (!isOpen) return null;
 
@@ -59,37 +81,45 @@ export const BossPreviewModal: React.FC<BossPreviewModalProps> = ({ isOpen, onCl
 
     const tilesById = useMemo(() => new Map(tileset.map(t => [t.id, t])), [tileset]);
 
-    // This is a placeholder. In a real scenario, you'd get this from the screen mode context.
-    const palette: MSXColor[] = MSX_SCREEN5_PALETTE;
-
     return (
         <Modal isOpen={isOpen} onClose={onClose} title="Boss Animation Preview">
-            <div className="bg-msx-bgcolor p-4 rounded-lg flex flex-col space-y-4">
-                <div
-                    className="grid bg-msx-checkerboard border-2 border-msx-border"
-                    style={{
-                        gridTemplateColumns: `repeat(${phaseGridWidth}, ${tileSize}px)`,
-                        gridTemplateRows: `repeat(${phaseGridHeight}, ${tileSize}px)`,
-                        width: `${phaseGridWidth * tileSize}px`,
-                        height: `${phaseGridHeight * tileSize}px`,
-                        imageRendering: 'pixelated',
-                    }}
-                >
-                    {currentPhase.tileMatrix?.flat().map((tileId, index) => {
-                        const tile = tileId ? tilesById.get(tileId) : null;
-                        // Assuming createTileDataURL can work without a full palette if colors are hex strings
-                        const dataUrl = tile ? createTileDataURL(tile, 0, 0, tile.width, tile.height, tile.width, "SCREEN 5 (Graphics IV)") : null;
-                        return (
-                            <div
-                                key={index}
-                                className="w-full h-full"
-                                style={{
-                                    backgroundImage: dataUrl ? `url(${dataUrl})` : 'none',
-                                    backgroundSize: 'cover',
-                                }}
-                            />
-                        );
-                    })}
+            <div className="bg-msx-bgcolor p-4 rounded-lg flex flex-col space-y-4 items-center">
+                <div className="relative bg-msx-checkerboard border-2 border-msx-border" style={{ width: 256, height: 192 }}>
+                    <canvas
+                        ref={backgroundCanvasRef}
+                        width="256"
+                        height="192"
+                        className="absolute top-0 left-0 w-full h-full"
+                        style={{ imageRendering: 'pixelated' }}
+                    />
+                    <div
+                        className="absolute grid"
+                        style={{
+                            gridTemplateColumns: `repeat(${phaseGridWidth}, ${tileSize}px)`,
+                            gridTemplateRows: `repeat(${phaseGridHeight}, ${tileSize}px)`,
+                            width: `${phaseGridWidth * tileSize}px`,
+                            height: `${phaseGridHeight * tileSize}px`,
+                            imageRendering: 'pixelated',
+                            top: '50%',
+                            left: '50%',
+                            transform: 'translate(-50%, -50%)',
+                        }}
+                    >
+                        {currentPhase.tileMatrix?.flat().map((tileId, index) => {
+                            const tile = tileId ? tilesById.get(tileId) : null;
+                            const dataUrl = tile ? createTileDataURL(tile, 0, 0, tile.width, tile.height, tile.width, "SCREEN 5 (Graphics IV)") : null;
+                            return (
+                                <div
+                                    key={index}
+                                    className="w-full h-full"
+                                    style={{
+                                        backgroundImage: dataUrl ? `url(${dataUrl})` : 'none',
+                                        backgroundSize: 'cover',
+                                    }}
+                                />
+                            );
+                        })}
+                    </div>
                 </div>
 
                 <div className="flex items-center space-x-2 text-xs w-full max-w-xs">

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "copy-of-copy-of-copy-of-copy-of--mideas---world-view.tsx",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/types.ts
+++ b/types.ts
@@ -420,6 +420,7 @@ export interface Boss {
   attacks: BossAttack[];
   deathExplosionSpriteId?: string;
   deathSoundId?: string;
+  linkedScreenId?: string | null;
 }
 
 // --- Main Menu Types ---


### PR DESCRIPTION
This commit introduces a new feature to the Boss Editor:

-   A dropdown menu has been added to the "General" properties panel, allowing a boss to be linked to any existing screen map.
-   When the "Preview Animation" button is clicked, the modal will now render the linked screen as a background.
-   The boss's animation is displayed statically in the center of the screen background.
-   If no screen is linked, the preview displays a checkerboard pattern as before.

This commit also increments the application version to 1.12.