### PR TITLE
Fix instruments always sounding like a piano

### DIFF
--- a/components/utils/aySynthesizer.ts
+++ b/components/utils/aySynthesizer.ts
@@ -95,6 +95,14 @@ export class AYSynthesizer {
      */
     public setSongData(songData: TrackerSongData): void {
         this.songDataRef = songData;
+        for (let i = 0; i < 3; i++) {
+            const ch = i as 0 | 1 | 2;
+            if (this.channelActiveInstrument[ch]) {
+                const activeId = this.channelActiveInstrument[ch]!.id;
+                const newInstrument = this.songDataRef.instruments.find(instr => instr.id === activeId);
+                this.channelActiveInstrument[ch] = newInstrument || null;
+            }
+        }
     }
 
     private getNotePeriod(noteString: string | null): number | null {


### PR DESCRIPTION
The synthesizer was caching active instrument data for each channel. When the song data was updated with modified instruments, this cache was not being invalidated or updated. This caused the synthesizer to continue using the old, stale instrument data, making it seem like instrument edits had no effect.

The `setSongData` function in `AYSynthesizer` has been updated to refresh the active instrument references for each channel whenever new song data is provided. This ensures that the synthesizer always uses the most up-to-date instrument definitions.