### PR TITLE
Fix SCREEN 5 carry-and-throw input

### DIFF
--- a/scripts/build_msx2_screen5_bitmap_room_smoke.py
+++ b/scripts/build_msx2_screen5_bitmap_room_smoke.py
@@ -466,6 +466,7 @@ def enable_all_bitmap_skills(project: dict[str, object]) -> None:
         "high_jump",
         "wall_break",
         "spin_attack",
+        "carry_and_throw",
     ]:
         if skill_id not in active_skills:
             active_skills.append(skill_id)
@@ -508,8 +509,37 @@ def enable_all_bitmap_skills(project: dict[str, object]) -> None:
             "spinCooldown": 30,
             "requireKeyRelease": True,
         },
+        "carry_and_throw": {
+            "throwSpeed": 12,
+            "throwVertical": 8,
+            "throwGravity": 1,
+            "throwCooldown": 30,
+            "pickupRadius": 20,
+            "objectCollision": True,
+            "enemyCollision": True,
+        },
     })
     player["skillParameters"] = skill_parameters
+    for asset in project["assets"]:
+        if asset.get("type") != "msx2bitmaproom":
+            continue
+        asset["data"]["entities"] = [
+            {
+                "kind": "carryable",
+                "position": {"x": 4, "y": 9},
+                "components": {
+                    "msx2_carryable": {"enabled": True},
+                    "msx2_hardware_sprite": {"msx2SpriteAssetId": "smoke_player_sprite"},
+                },
+            },
+            {
+                "kind": "enemy",
+                "position": {"x": 9, "y": 9},
+                "components": {
+                    "msx2_hardware_sprite": {"msx2SpriteAssetId": "smoke_player_sprite"},
+                },
+            },
+        ]
 
 
 def render_smoke_room_data(room: dict[str, object]) -> list[list[int]]:
@@ -832,6 +862,9 @@ def validate_all_bitmap_skill_markers(asm_text: str) -> None:
         "bitmap_highjump_arm",
         "bitmap_try_wall_break",
         "bitmap_try_spin_attack",
+        "update_bitmap_carry_and_throw",
+        "bitmap_update_carry_sat",
+        "bitmap_carry_check_enemy_collision",
     ):
         if marker not in asm_text:
             raise RuntimeError(f"All-bitmap-skills smoke is missing ASM marker: {marker}")

--- a/utils/msx2PlatformPhysics.ts
+++ b/utils/msx2PlatformPhysics.ts
@@ -190,6 +190,8 @@ export interface Msx2CarryAndThrowConfig {
   enemyCollision: boolean;
   primaryControl: Msx2PlayerControlId;
   secondaryControl: Msx2PlayerControlId | 'none';
+  primaryKeyboard?: Msx2BitmapKeyboardBinding;
+  secondaryKeyboard?: Msx2BitmapKeyboardBinding;
 }
 
 /**
@@ -889,6 +891,8 @@ export function getMsx2CarryAndThrowConfigFromPlayerEntity(player: any | undefin
     enemyCollision: params.enemyCollision !== false,
     primaryControl: binding.primary,
     secondaryControl: binding.secondary,
+    primaryKeyboard: resolveMsx2BitmapKeyboardBinding(player, binding.primary),
+    secondaryKeyboard: resolveMsx2BitmapKeyboardBinding(player, binding.secondary),
   };
 }
 

--- a/utils/msxGenerator/generators/msx2/msx2BitmapCarryAndThrowGenerator.ts
+++ b/utils/msxGenerator/generators/msx2/msx2BitmapCarryAndThrowGenerator.ts
@@ -2,7 +2,6 @@ import { Msx2CarryAndThrowConfig } from '../../../msx2PlatformPhysics';
 import { Msx2Screen5BitmapRoom } from '../../../../types';
 import { buildHardwareSpriteLayersForFrame, resolveMsx2SpriteById } from './msx2Screen4Generator';
 import { isMsx2CarryableEntity } from './msx2CarryObjectGenerator';
-import { buildMsx2SkillPressedRoutine } from './msx2SkillControlsGenerator';
 
 /** Maximum number of carryable objects exported per SCREEN 5 room. */
 export const BITMAP_MAX_CARRY_AND_THROW_SLOTS = 2;
@@ -21,6 +20,31 @@ function asmByte(value: number): string {
 
 function asmWord(value: number): string {
   return `#${Math.max(0, Math.min(0xFFFF, Math.floor(Number(value) || 0))).toString(16).toUpperCase().padStart(4, '0')}`;
+}
+
+function buildCarryInputRoutine(config: Msx2CarryAndThrowConfig): string {
+  const key = config.primaryKeyboard || { label: 'M', row: 4, mask: 0x04 };
+  const mask = asmByte(key.mask);
+  return `bitmap_carry_and_throw_pressed:
+    ; ------------------------------------------------------------
+    ; FUNCTION: bitmap_carry_and_throw_pressed
+    ; PURPOSE: Reads the configured carry/throw keyboard binding directly from PPI.
+    ; INPUT: none.
+    ; OUTPUT: A=1 while pressed, A=0 otherwise (Z set when released).
+    ; DESTROYS: AF.
+    ; PRESERVES: BC, DE, HL, IX, IY.
+    ; ------------------------------------------------------------
+    in a, (PPI_C)
+    and #F0
+    or ${key.row}
+    out (PPI_C), a
+    in a, (PPI_B)
+    cpl
+    and ${mask}
+    ret z
+    ld a, 1
+    ret
+`;
 }
 
 function clampTile(value: unknown, max: number): number {
@@ -334,12 +358,7 @@ bitmap_carry_check_enemy_collision:
     ret
 `;
 
-  const routinesAsm = `${buildMsx2SkillPressedRoutine(
-    'bitmap_carry_and_throw_pressed',
-    'SCREEN 5 carry and throw skill',
-    config!.primaryControl,
-    config!.secondaryControl,
-  )}
+  const routinesAsm = `${buildCarryInputRoutine(config!)}
 ; FUNCTION: bitmap_load_carry_objects
 ; PURPOSE: Loads the active room's carryable positions and sprite graphics.
 ; INPUT: current_screen_index.


### PR DESCRIPTION
## Cambios\n- Corrige la lectura de la tecla configurada para carry_and_throw en SCREEN 5 usando el PPI directamente.\n- Expone la configuración de teclado en el resolver de física.\n- Amplía el smoke real con objeto recogible, enemigo y marcadores de pickup, lanzamiento y colisión.\n\n## Validación\n- Smoke SCREEN 5 compilado con Glass.jar: ROM de 32768 bytes.\n- check_screen5_carry_and_throw_contract.mjs: 8/8.\n- check_skill_params_contract.cjs: 92/92.\n- npm run build: correcto; solo quedan avisos de chunks grandes.