### PR TITLE
Add destroy_tile skill for SCREEN 5 bitmap rooms

### DIFF
--- a/components/dialogs/skills/DestroyTileDialog.tsx
+++ b/components/dialogs/skills/DestroyTileDialog.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import type { ProjectAsset } from '../../../types';
+import type { SkillParameterDef } from '../../../utils/msxGenerator/skills/types';
+
+const inputClass = 'w-full rounded border border-slate-600 bg-[#111821] px-2 py-1 text-xs text-slate-200 focus:border-sky-600 focus:outline-none';
+const selectClass = inputClass;
+
+/**
+ * Dedicated parameters dialog for the destroy_tile (dig) skill.
+ *
+ * Renders the declarative numeric/boolean parameters (digKey, hitsPerTile, …)
+ * exactly like the generic SkillParametersDialog, then adds two sprite-asset
+ * selectors that the generic dialog cannot express:
+ *
+ *   1. Debris sprite   -> written to player.render.debrisSpriteAssetId
+ *                         (consumed by resolveBitmapDebrisSprite).
+ *   2. Digging sprite  -> written to player.render.stateSprites['digging']
+ *                         (consumed by resolveBitmapRoomStateAnimations, which
+ *                         maps the 'digging' animation state to its own frame
+ *                         bank and asserts it while the pick is swinging).
+ *
+ * Both are optional: leaving them blank keeps the existing fallbacks (a sprite
+ * named /debris|viruta/i or the built-in chip; the Player Animations table row
+ * for the digging state).
+ */
+interface DestroyTileDialogProps {
+  parameters: SkillParameterDef[];
+  values: Record<string, number | boolean>;
+  onPatch: (key: string, value: number | boolean) => void;
+  spriteAssets: ProjectAsset[];
+  debrisSpriteAssetId: string | undefined;
+  diggingSpriteAssetId: string | undefined;
+  onDebrisChange: (spriteAssetId: string | undefined) => void;
+  onDiggingChange: (spriteAssetId: string | undefined) => void;
+  onClose: () => void;
+}
+
+export const DestroyTileDialog: React.FC<DestroyTileDialogProps> = ({
+  parameters,
+  values,
+  onPatch,
+  spriteAssets,
+  debrisSpriteAssetId,
+  diggingSpriteAssetId,
+  onDebrisChange,
+  onDiggingChange,
+  onClose,
+}) => (
+  <div
+    className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+    onMouseDown={event => {
+      if (event.target === event.currentTarget) onClose();
+    }}
+    role="dialog"
+    aria-modal="true"
+    aria-label="Destroy Tile parameters"
+  >
+    <div className="flex max-h-[86vh] w-full max-w-lg flex-col overflow-hidden rounded-lg border border-slate-700 bg-[#151a23] shadow-xl">
+      <div className="flex items-center justify-between border-b border-slate-700 px-4 py-3">
+        <div className="flex items-center gap-3">
+          <span className="text-2xl">⛏️</span>
+          <div>
+            <h3 className="text-sm font-semibold text-slate-100">Destroy Tile (dig)</h3>
+            <div className="flex items-center gap-2">
+              <span className="text-[10px] font-medium text-yellow-400">UTILITY</span>
+              <span className="text-[10px] text-slate-500">·</span>
+              <span className="text-[10px] text-slate-400">Pick at the wall ahead to dissolve destructible tiles</span>
+            </div>
+          </div>
+        </div>
+        <button
+          type="button"
+          className="rounded border border-slate-700 px-3 py-1.5 text-xs text-slate-300 hover:bg-slate-800 hover:text-slate-100"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto p-4 space-y-4">
+        {/* Numeric / boolean skill parameters (single source of truth: destroy_tile.json). */}
+        <div className="grid grid-cols-2 gap-3">
+          {parameters.map((param: SkillParameterDef) => {
+            const raw = values[param.key];
+            const fallback = param.default;
+            if (param.type === 'boolean') {
+              const checked = raw === undefined ? Boolean(fallback) : Boolean(raw);
+              return (
+                <label
+                  key={param.key}
+                  className="col-span-2 flex items-start gap-3 rounded border border-slate-700 bg-[#111821] px-3 py-2.5 text-xs text-slate-100"
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={event => onPatch(param.key, event.target.checked)}
+                    className="mt-0.5 h-4 w-4 shrink-0 accent-sky-500"
+                  />
+                  <span className="space-y-0.5">
+                    <span className="block font-medium">{param.label}</span>
+                    {param.help && <span className="block text-[10px] leading-relaxed text-slate-400">{param.help}</span>}
+                  </span>
+                </label>
+              );
+            }
+            const numValue = Number(raw);
+            const safeValue = Number.isFinite(numValue) ? numValue : Number(fallback) || 0;
+            return (
+              <div key={param.key} className="space-y-1.5 text-xs text-slate-200">
+                <label className="flex items-center justify-between gap-2">
+                  <span className="text-slate-300">{param.label}</span>
+                  <span className="min-w-[40px] rounded bg-slate-800 px-1.5 py-0.5 text-center text-[10px] text-sky-400">
+                    {safeValue}
+                  </span>
+                </label>
+                <input
+                  type="number"
+                  min={param.min}
+                  max={param.max}
+                  step={param.step ?? 1}
+                  className={inputClass}
+                  value={safeValue}
+                  onChange={event => {
+                    let next = Number(event.target.value);
+                    if (!Number.isFinite(next)) next = Number(fallback) || 0;
+                    if (typeof param.min === 'number') next = Math.max(param.min, next);
+                    if (typeof param.max === 'number') next = Math.min(param.max, next);
+                    onPatch(param.key, next);
+                  }}
+                />
+                {param.help && <p className="text-[10px] leading-relaxed text-slate-400">{param.help}</p>}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Graphics: sprite-asset selectors that the generic dialog cannot render. */}
+        <div className="space-y-3 rounded border border-slate-700 bg-[#111821] p-3">
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-sky-300">Graphics</p>
+          <div className="space-y-1.5 text-xs text-slate-200">
+            <label className="block text-slate-300">Debris sprite (virutas)</label>
+            <select
+              className={selectClass}
+              value={debrisSpriteAssetId || ''}
+              onChange={event => onDebrisChange(event.target.value || undefined)}
+            >
+              <option value="">(fallback: /debris|viruta/ sprite or built-in chip)</option>
+              {spriteAssets.map(asset => (
+                <option key={asset.id} value={asset.id}>{asset.name}</option>
+              ))}
+            </select>
+            <p className="text-[10px] leading-relaxed text-slate-400">
+              Hardware sprite spawned as chips when a tile is hit. Its first frame is used.
+            </p>
+          </div>
+          <div className="space-y-1.5 text-xs text-slate-200">
+            <label className="block text-slate-300">Digging animation sprite</label>
+            <select
+              className={selectClass}
+              value={diggingSpriteAssetId || ''}
+              onChange={event => onDiggingChange(event.target.value || undefined)}
+            >
+              <option value="">(fallback: Player Animations row for 'digging')</option>
+              {spriteAssets.map(asset => (
+                <option key={asset.id} value={asset.id}>{asset.name}</option>
+              ))}
+            </select>
+            <p className="text-[10px] leading-relaxed text-slate-400">
+              Sprite played while the pick is swinging. Overrides the Player Animations table
+              for the 'digging' state. Rendered on the same cell grid as the base sprite.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div className="border-t border-slate-700 px-4 py-2">
+        <p className="text-[10px] text-slate-500">Changes apply immediately · Skill ID: destroy_tile</p>
+      </div>
+    </div>
+  </div>
+);
+
+export default DestroyTileDialog;

--- a/components/dialogs/skills/index.ts
+++ b/components/dialogs/skills/index.ts
@@ -16,3 +16,4 @@ export { CarryObjectDialog } from './CarryObjectDialog';
 export { TeleportABDialog } from './TeleportABDialog';
 export { CarryAndThrowDialog } from './CarryAndThrowDialog';
 export { PowerStompDialog } from './PowerStompDialog';
+export { DestroyTileDialog } from './DestroyTileDialog';

--- a/components/editors/Msx2BitmapScreenEditor.tsx
+++ b/components/editors/Msx2BitmapScreenEditor.tsx
@@ -73,6 +73,7 @@ import {
   PencilIcon,
   PlusCircleIcon,
   SaveIcon,
+  SelectionIcon,
   SpriteIcon,
   ZoomInIcon,
   ZoomOutIcon,
@@ -90,7 +91,7 @@ import {
  * label says "SCREEN 5" (this is the MSX2 bitmap SCREEN 5 mode).
  */
 
-type BrushTool = 'brush' | 'eraser' | 'fill';
+type BrushTool = 'brush' | 'eraser' | 'fill' | 'select';
 type LayerKey = 'visual' | 'collision' | 'objects' | 'foreground';
 type CategoryKey = 'suelo' | 'pared' | 'decoracion' | 'interactivos';
 type CategoryFilterKey = 'all' | CategoryKey;
@@ -126,6 +127,11 @@ const PROP_BIT: Record<string, number> = {
   solid: 0x10,        // high nibble = family/solidity
   platform: 0x20,
   deadly: 0x40,
+  // destroy_tile (pico) diggable bit, per collision CELL. High-nibble bit, so it also
+  // reads as SOLID at runtime (probe `and #BF`) — a dug wall is solid until destroyed.
+  // This lets the SAME visual tile be diggable in one cell and only-solid in another
+  // (secret paths). Painting a "Destructible" atlas tile stamps it; Select toggles it.
+  destructible: 0x80,
 };
 
 const PROPERTY_FLAGS: { key: string; label: string }[] = [
@@ -2805,8 +2811,12 @@ export const Msx2BitmapScreenEditor: React.FC<Msx2BitmapScreenEditorProps> = ({ 
       return;
     }
     if (activeLayer === 'visual') {
-      paintVisualAt(px, py);
-      setStatusBarMessage?.(`SCREEN 5: ${tool} en celda (${cellX}, ${cellY}).`);
+      if (tool === 'select') {
+        setStatusBarMessage?.(`SCREEN 5: tile seleccionado en celda (${cellX}, ${cellY}).`);
+      } else {
+        paintVisualAt(px, py);
+        setStatusBarMessage?.(`SCREEN 5: ${tool} en celda (${cellX}, ${cellY}).`);
+      }
     } else if (activeLayer === 'foreground') {
       paintForegroundAt(px, py, false);
     } else {
@@ -2825,7 +2835,7 @@ export const Msx2BitmapScreenEditor: React.FC<Msx2BitmapScreenEditorProps> = ({ 
   const handleCanvasMove = (event: React.MouseEvent<HTMLCanvasElement>) => {
     if (!isPainting) return;
     // Drag-fill would re-clear the whole page each move; only stamp for brush/eraser.
-    if (tool === 'fill') return;
+    if (tool === 'fill' || tool === 'select') return;
     if (activeLayer === 'visual' && tool === 'brush' && preparedStamp) return;
     // Entities layer places/selects on click only — never on drag (avoids spamming entities).
     if (activeLayer === 'objects') {
@@ -3471,7 +3481,12 @@ export const Msx2BitmapScreenEditor: React.FC<Msx2BitmapScreenEditorProps> = ({ 
       }
     : null;
 
-  const selectedAtlasEntryFlags = selectedAtlasEntry ? clampByte(selectedAtlasEntry.collisionFlags, 0) : 0;
+  // Painting a "Destructible" atlas tile stamps the per-cell destructible bit (0x80)
+  // into the cell's collision byte, so the dug-mask default follows the atlas checkbox
+  // while the Select tool can still toggle individual cells (secret paths).
+  const selectedAtlasEntryFlags = selectedAtlasEntry
+    ? clampByte(selectedAtlasEntry.collisionFlags, 0) | (selectedAtlasEntry.destructible === true ? PROP_BIT.destructible : 0)
+    : 0;
   const selectedAtlasEntryBehaviorCode = selectedAtlasEntry ? clampByte(selectedAtlasEntry.behaviorCode, 0) : 0;
   const getConfigAtlasEntryIds = (): string[] => {
     if (configTarget !== 'tile') return [];
@@ -3525,7 +3540,10 @@ export const Msx2BitmapScreenEditor: React.FC<Msx2BitmapScreenEditorProps> = ({ 
     const next: Record<string, boolean> = {};
     PROPERTY_FLAGS.forEach(flag => { next[flag.key] = (configFlags & PROP_BIT[flag.key]) !== 0; });
     next.ice = configBehaviorCode === BEHAVIOR_CODE.ice;
-    next.destructible = configTarget !== 'cell' && selectedAtlasEntryDestructible;
+    // Destructible reads the per-cell 0x80 bit for a cell, or the atlas tile flag for a tile.
+    next.destructible = configTarget === 'cell'
+      ? (configFlags & PROP_BIT.destructible) !== 0
+      : selectedAtlasEntryDestructible;
     setCellProps(next);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [configTarget, selectedCollisionCell?.x, selectedCollisionCell?.y, room.collision, room.behavior, selectedAtlasEntry?.id, selectedAtlasEntryFlags, selectedAtlasEntryBehaviorCode, selectedAtlasEntryDestructible]);
@@ -3648,12 +3666,24 @@ export const Msx2BitmapScreenEditor: React.FC<Msx2BitmapScreenEditorProps> = ({ 
     );
   };
 
-  // destroy_tile skill: per-atlas-entry "diggable" mark. Pure tile metadata (the
-  // ASM generator derives destructible CELLS from tileGrid + this flag at build
-  // time), so unlike Ice there is no per-cell grid to sync.
+  // destroy_tile skill: "diggable" mark. Two scopes:
+  //  - CELL: toggles the per-cell 0x80 bit in the collision grid (source of truth for
+  //    the generator's dug-mask). Lets the same visual tile be diggable in one cell and
+  //    only-solid in another → secret paths.
+  //  - TILE: toggles the atlas entry's `destructible` flag, which becomes the painting
+  //    default (paint stamps the 0x80 bit) for every cell drawn with that tile.
   const toggleDestructible = () => {
     if (configTarget === 'cell') {
-      setStatusBarMessage?.('Destructible se marca en el TILE del atlas (cambia a "Usar tile").');
+      if (!selectedCollisionCell) {
+        setStatusBarMessage?.('Selecciona una celda del lienzo primero (herramienta Select).');
+        return;
+      }
+      const bit = PROP_BIT.destructible;
+      const current = readCell(room.collision, selectedCollisionCell.x, selectedCollisionCell.y);
+      const nextValue = (current & bit) ? (current & ~bit) : (current | bit);
+      const grown = writeCell(room.collision, selectedCollisionCell.x, selectedCollisionCell.y, nextValue, collisionCols, collisionRows);
+      onUpdate({ collision: grown });
+      setStatusBarMessage?.(`SCREEN 5: Destructible ${(nextValue & bit) ? 'ON' : 'OFF'} en celda (${selectedCollisionCell.x}, ${selectedCollisionCell.y}) (skill destroy_tile).`);
       return;
     }
     const targetEntryIds = getConfigAtlasEntryIds();
@@ -3669,11 +3699,38 @@ export const Msx2BitmapScreenEditor: React.FC<Msx2BitmapScreenEditorProps> = ({ 
     const entries = atlasEntries.map(entry => targetSet.has(entry.id)
       ? { ...entry, destructible: turnOn || undefined }
       : entry);
-    onUpdate({ atlas: { ...room.atlas, entries } });
+    // Sync the per-cell 0x80 bit into every cell already using this tile (mirrors the Ice
+    // sync), so the atlas checkbox reliably stamps the source-of-truth bit even for cells
+    // painted before the toggle. Individual cells can still be overridden with Select.
+    const bit = PROP_BIT.destructible;
+    let syncedCells = 0;
+    let nextCollision = room.collision;
+    atlasEntries.forEach((entry, index) => {
+      if (!targetSet.has(entry.id)) return;
+      const tileIndexToSync = index + 1;
+      tileGrid.forEach((row, y) => {
+        row.forEach((tileIndex, x) => {
+          if (tileIndex !== tileIndexToSync) return;
+          const before = readCell(nextCollision, x, y);
+          const after = turnOn ? (before | bit) : (before & ~bit);
+          if (after === before) return;
+          nextCollision = writeCell(nextCollision, x, y, after, collisionCols, collisionRows);
+          syncedCells++;
+        });
+      });
+    });
+    onUpdate({
+      atlas: { ...room.atlas, entries },
+      ...(syncedCells > 0 ? { collision: nextCollision } : {}),
+    });
     const targetLabel = targetEntryIds.length > 1
       ? `${targetEntryIds.length} tiles del metatile`
       : `tile "${selectedAtlasEntry?.name || atlasEntries.find(entry => targetSet.has(entry.id))?.name || 'atlas'}"`;
-    setStatusBarMessage?.(`SCREEN 5: Destructible ${turnOn ? 'ON' : 'OFF'} en ${targetLabel} (skill destroy_tile).`);
+    setStatusBarMessage?.(
+      `SCREEN 5: Destructible ${turnOn ? 'ON' : 'OFF'} en ${targetLabel}` +
+      (syncedCells > 0 ? `; ${syncedCells} celda(s) sincronizada(s)` : '') +
+      ' (skill destroy_tile).'
+    );
   };
 
   const selectedCellSlot = selectedCell ? composedPixels[selectedCell.y * GRID]?.[selectedCell.x * GRID] ?? 0 : 0;
@@ -3736,6 +3793,7 @@ export const Msx2BitmapScreenEditor: React.FC<Msx2BitmapScreenEditorProps> = ({ 
         <aside className="w-60 border-r border-msx-border p-2 overflow-y-auto space-y-2">
           <CollapsiblePanel title="Herramientas" isOpen={openTools} onToggle={() => setOpenTools(v => !v)}>
             <div className="grid grid-cols-1 gap-1">
+              {toolBtn('select', 'Select', <SelectionIcon />)}
               {toolBtn('brush', 'Pincel', <PencilIcon />)}
               {toolBtn('eraser', 'Borrador', <EraserIcon />)}
               {toolBtn('fill', 'Rellenar', <PaintBrushIcon />)}
@@ -5469,13 +5527,14 @@ export const Msx2BitmapScreenEditor: React.FC<Msx2BitmapScreenEditorProps> = ({ 
                 Ice (behavior=3)
               </label>
               <label
-                className={`flex items-center gap-1 text-xs ${configTarget === 'cell' ? 'text-msx-textsecondary/50' : 'text-msx-textsecondary'}`}
-                title="Skill destroy_tile: el player puede picar y disolver las celdas pintadas con este tile."
+                className="flex items-center gap-1 text-xs text-msx-textsecondary"
+                title={configTarget === 'cell'
+                  ? 'Skill destroy_tile: SOLO esta celda se puede picar. Usa el mismo tile solido en otra celda para caminos secretos.'
+                  : 'Skill destroy_tile: al pintar este tile, las celdas quedan picables por defecto (puedes desmarcar celdas sueltas con Select).'}
               >
                 <input
                   type="checkbox"
                   checked={!!cellProps.destructible}
-                  disabled={configTarget === 'cell'}
                   onChange={toggleDestructible}
                 />
                 Destructible (pico)

--- a/components/editors/Msx2BitmapScreenEditor.tsx
+++ b/components/editors/Msx2BitmapScreenEditor.tsx
@@ -3503,6 +3503,7 @@ export const Msx2BitmapScreenEditor: React.FC<Msx2BitmapScreenEditorProps> = ({ 
     onUpdateProjectAsset(selectedStampAsset.id, updatedEntry);
     return true;
   };
+  const selectedAtlasEntryDestructible = selectedAtlasEntry?.destructible === true;
   const selectedCellBehaviorCode = selectedCollisionCell
     ? readCell(room.behavior, selectedCollisionCell.x, selectedCollisionCell.y)
     : 0;
@@ -3524,9 +3525,10 @@ export const Msx2BitmapScreenEditor: React.FC<Msx2BitmapScreenEditorProps> = ({ 
     const next: Record<string, boolean> = {};
     PROPERTY_FLAGS.forEach(flag => { next[flag.key] = (configFlags & PROP_BIT[flag.key]) !== 0; });
     next.ice = configBehaviorCode === BEHAVIOR_CODE.ice;
+    next.destructible = configTarget !== 'cell' && selectedAtlasEntryDestructible;
     setCellProps(next);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [configTarget, selectedCollisionCell?.x, selectedCollisionCell?.y, room.collision, room.behavior, selectedAtlasEntry?.id, selectedAtlasEntryFlags, selectedAtlasEntryBehaviorCode]);
+  }, [configTarget, selectedCollisionCell?.x, selectedCollisionCell?.y, room.collision, room.behavior, selectedAtlasEntry?.id, selectedAtlasEntryFlags, selectedAtlasEntryBehaviorCode, selectedAtlasEntryDestructible]);
 
   const toggleProp = (key: string) => {
     const bit = PROP_BIT[key];
@@ -3644,6 +3646,34 @@ export const Msx2BitmapScreenEditor: React.FC<Msx2BitmapScreenEditorProps> = ({ 
       (syncedCells > 0 ? `; ${syncedCells} celda(s) sincronizada(s)` : '') +
       (persistedStamp ? '; metatile actualizado.' : '.')
     );
+  };
+
+  // destroy_tile skill: per-atlas-entry "diggable" mark. Pure tile metadata (the
+  // ASM generator derives destructible CELLS from tileGrid + this flag at build
+  // time), so unlike Ice there is no per-cell grid to sync.
+  const toggleDestructible = () => {
+    if (configTarget === 'cell') {
+      setStatusBarMessage?.('Destructible se marca en el TILE del atlas (cambia a "Usar tile").');
+      return;
+    }
+    const targetEntryIds = getConfigAtlasEntryIds();
+    if (targetEntryIds.length === 0) {
+      setStatusBarMessage?.('Selecciona un tile del atlas primero.');
+      return;
+    }
+    const targetSet = new Set(targetEntryIds);
+    const current = selectedAtlasEntry && targetSet.has(selectedAtlasEntry.id)
+      ? selectedAtlasEntry.destructible === true
+      : atlasEntries.find(entry => targetSet.has(entry.id))?.destructible === true;
+    const turnOn = !current;
+    const entries = atlasEntries.map(entry => targetSet.has(entry.id)
+      ? { ...entry, destructible: turnOn || undefined }
+      : entry);
+    onUpdate({ atlas: { ...room.atlas, entries } });
+    const targetLabel = targetEntryIds.length > 1
+      ? `${targetEntryIds.length} tiles del metatile`
+      : `tile "${selectedAtlasEntry?.name || atlasEntries.find(entry => targetSet.has(entry.id))?.name || 'atlas'}"`;
+    setStatusBarMessage?.(`SCREEN 5: Destructible ${turnOn ? 'ON' : 'OFF'} en ${targetLabel} (skill destroy_tile).`);
   };
 
   const selectedCellSlot = selectedCell ? composedPixels[selectedCell.y * GRID]?.[selectedCell.x * GRID] ?? 0 : 0;
@@ -5437,6 +5467,18 @@ export const Msx2BitmapScreenEditor: React.FC<Msx2BitmapScreenEditorProps> = ({ 
               <label className="flex items-center gap-1 text-xs text-msx-textsecondary">
                 <input type="checkbox" checked={!!cellProps.ice} onChange={toggleIceSurface} />
                 Ice (behavior=3)
+              </label>
+              <label
+                className={`flex items-center gap-1 text-xs ${configTarget === 'cell' ? 'text-msx-textsecondary/50' : 'text-msx-textsecondary'}`}
+                title="Skill destroy_tile: el player puede picar y disolver las celdas pintadas con este tile."
+              >
+                <input
+                  type="checkbox"
+                  checked={!!cellProps.destructible}
+                  disabled={configTarget === 'cell'}
+                  onChange={toggleDestructible}
+                />
+                Destructible (pico)
               </label>
             </div>
             <div className="mt-2 rounded border border-msx-border bg-msx-bgcolor px-2 py-1 text-[0.65rem] text-msx-textsecondary">

--- a/components/editors/Msx2PlayerEditor.tsx
+++ b/components/editors/Msx2PlayerEditor.tsx
@@ -15,6 +15,7 @@ import { resolveGraphicsBackend } from '../../utils/msxGenerator';
 import type { GraphicsBackend } from '../../utils/msxGenerator/graphicsBackend';
 import type { SkillControlIcon, SkillDef, SkillParameterDef } from '../../utils/msxGenerator/skills/types';
 import { BulletConfigDialog } from '../dialogs/skills/BulletConfigDialog';
+import { DestroyTileDialog } from '../dialogs/skills/DestroyTileDialog';
 
 interface Msx2PlayerEditorProps {
   player: Msx2PlayerDefinition | Record<string, unknown>;
@@ -497,6 +498,7 @@ const skillMeta: Record<string, { icon: string; category: string; description: s
   teleport_a_b: { icon: '🌀', category: 'movement', description: 'Teleport between two saved positions' },
   carry_and_throw: { icon: '🏋️', category: 'utility', description: 'Lift objects and throw them through gaps' },
   power_stomp: { icon: '💥', category: 'attack', description: 'Fall with impact, break tiles and damage enemies' },
+  destroy_tile: { icon: '⛏️', category: 'utility', description: 'Pick at the wall ahead to dissolve destructible tiles' },
 };
 
 const categoryColors: Record<string, string> = {
@@ -1354,6 +1356,14 @@ export const Msx2PlayerEditor: React.FC<Msx2PlayerEditorProps> = ({ player, play
         [skillId]: skillEntry,
       },
     });
+  };
+  // Patch a single per-state sprite override on render.stateSprites without
+  // clobbering the other states. Passing undefined removes the entry.
+  const updateRenderStateSprite = (state: string, spriteAssetId: string | undefined) => {
+    const currentStateSprites = { ...((normalized.render.stateSprites as Record<string, string> | undefined) || {}) };
+    if (spriteAssetId) currentStateSprites[state] = spriteAssetId;
+    else delete currentStateSprites[state];
+    updateRender({ stateSprites: currentStateSprites });
   };
   const addWeapon = () => {
     const existingIds = new Set(weapons.map(weapon => weapon.id));
@@ -2891,6 +2901,24 @@ export const Msx2PlayerEditor: React.FC<Msx2PlayerEditorProps> = ({ player, play
           const skill = (getAllSkills() as SkillDef[]).find(s => s.id === openSkillDialogId);
           if (!skill || !skill.parameters?.length) return null;
           const skillValues = normalized.skillParameters?.[skill.id] || {};
+          // destroy_tile needs two sprite-asset selectors (debris chip + digging
+          // animation) the generic number/boolean dialog cannot render.
+          if (skill.id === 'destroy_tile') {
+            const diggingSpriteAssetId = (normalized.render.stateSprites as Record<string, string> | undefined)?.digging;
+            return (
+              <DestroyTileDialog
+                parameters={skill.parameters}
+                values={skillValues}
+                onPatch={(key, value) => updateSkillParameter(skill.id, key, value)}
+                spriteAssets={spriteAssets}
+                debrisSpriteAssetId={normalized.render.debrisSpriteAssetId}
+                diggingSpriteAssetId={diggingSpriteAssetId}
+                onDebrisChange={spriteAssetId => updateRender({ debrisSpriteAssetId: spriteAssetId })}
+                onDiggingChange={spriteAssetId => updateRenderStateSprite('digging', spriteAssetId)}
+                onClose={() => setOpenSkillDialogId(null)}
+              />
+            );
+          }
           return (
             <SkillParametersDialog
               skill={skill}

--- a/test/msx2-destroy/.gitignore
+++ b/test/msx2-destroy/.gitignore
@@ -1,0 +1,6 @@
+*.rom
+*.asm
+*.sym
+*.json
+*.png
+*.txt

--- a/test/msx2-destroy/destroy_diag3.tcl
+++ b/test/msx2-destroy/destroy_diag3.tcl
@@ -1,0 +1,45 @@
+set result_path "test/msx2-destroy/destroy_diag3.txt"
+proc collrow {row} {
+    set base [expr {0xC010 + $row * 16}]
+    set out ""
+    for {set x 0} {$x < 16} {incr x} {
+        set v [debug read memory [expr {$base + $x}]]
+        append out [expr {$v ? "#" : "."}]
+    }
+    return $out
+}
+proc snap {label} {
+    global result_path
+    set f [open $result_path a]
+    set cd  [debug read memory 0xC2D0]
+    set hits [debug read memory 0xC2D3]
+    set tgt [debug read memory 0xC2D2]
+    set cnt [debug read memory 0xC2D5]
+    set px  [debug read memory 0xC001]
+    set py  [debug read memory 0xC000]
+    puts $f "$label cooldown=$cd hits=$hits target=$tgt count=$cnt pos=($px,$py)"
+    foreach r {7 8 9 10 11} { puts $f "  row$r [collrow $r]" }
+    close $f
+}
+after time 6  { keymatrixdown 8 0x01 }
+after time 7  { keymatrixup 8 0x01 }
+after time 8  { keymatrixdown 8 0x01 }
+after time 9  { keymatrixup 8 0x01 }
+after time 10 { keymatrixdown 8 0x01 }
+after time 11 { keymatrixup 8 0x01 }
+after time 13 {
+    snap "boot"
+    debug write memory 0xC001 96
+    debug write memory 0xC000 144
+    debug write memory 0xC008 0
+    keymatrixdown 8 0x10
+    keymatrixdown 2 0x80
+}
+after time 15 { snap "t15" }
+after time 18 { snap "t18" }
+after time 21 {
+    keymatrixup 8 0x10
+    keymatrixup 2 0x80
+    snap "end"
+    after time 1 { exit }
+}

--- a/test/msx2-destroy/destroy_persist2.tcl
+++ b/test/msx2-destroy/destroy_persist2.tcl
@@ -1,0 +1,63 @@
+set result_path "test/msx2-destroy/destroy_persist2.txt"
+proc snap {label} {
+    global result_path
+    set f [open $result_path a]
+    set cnt [debug read memory 0xC2D5]
+    set scr [debug read memory 0xC00B]
+    set px  [debug read memory 0xC001]
+    set py  [debug read memory 0xC000]
+    set c39  [debug read memory 0xC0A3]
+    set c29  [debug read memory 0xC0A2]
+    set c310 [debug read memory 0xC0B3]
+    set c210 [debug read memory 0xC0B2]
+    puts $f "$label count=$cnt screen=$scr pos=($px,$py) c(3,9)=$c39 c(2,9)=$c29 c(3,10)=$c310 c(2,10)=$c210"
+    close $f
+}
+proc poll_home {} {
+    set scr [debug read memory 0xC00B]
+    if {$scr == 1} {
+        keymatrixup 8 0x10
+        keymatrixup 2 0x80
+        after time 0.5 {
+            snap "back_home"
+            screenshot test/msx2-destroy/destroy_back.png
+            after time 1 { exit }
+        }
+    } else {
+        after time 0.25 { poll_home }
+    }
+}
+after time 6  { keymatrixdown 8 0x01 }
+after time 7  { keymatrixup 8 0x01 }
+after time 8  { keymatrixdown 8 0x01 }
+after time 9  { keymatrixup 8 0x01 }
+after time 10 { keymatrixdown 8 0x01 }
+after time 11 { keymatrixup 8 0x01 }
+after time 13 {
+    snap "boot"
+    debug write memory 0xC001 96
+    debug write memory 0xC000 144
+    debug write memory 0xC008 0
+    keymatrixdown 8 0x10
+    keymatrixdown 2 0x80
+}
+after time 14.3 {
+    keymatrixup 8 0x10
+    keymatrixup 2 0x80
+    snap "after_dig"
+    screenshot test/msx2-destroy/destroy_dig.png
+}
+after time 15 {
+    debug write memory 0xC001 200
+    debug write memory 0xC000 128
+    debug write memory 0xC008 1
+    keymatrixdown 8 0x80
+}
+after time 18 {
+    keymatrixup 8 0x80
+    snap "east_room"
+    keymatrixdown 8 0x10
+    keymatrixdown 2 0x80
+    poll_home
+}
+after time 40 { exit }

--- a/test/msx2-destroy/make_fixture.py
+++ b/test/msx2-destroy/make_fixture.py
@@ -1,0 +1,40 @@
+"""Builds the destroy_tile smoke fixture from any MSX2 bitmap-room project JSON.
+
+Usage: python make_fixture.py <project.json> [fixture_on.json]
+
+Enables the destroy_tile skill on the player (digKey=B, hitsPerTile=2,
+digCooldown=8, hold-to-dig) and marks EVERY atlas entry of every bitmap room
+as destructible, so any solid wall can be dug during the smoke. Keeps the
+Game Flow intact (removing it would reroute the build to the presentation
+backend). Then:
+
+  python ../../scripts/build_mideas_unified_rom.py --json fixture_on.json \
+      --project-root ../.. --asm-output on.asm --rom-output on.rom \
+      --allow-tsc-errors --rom-mode megarom --target-format konami
+  openmsx -machine C-BIOS_MSX2 -cart on.rom -romtype konami \
+      -script destroy_persist2.tcl     # or destroy_diag3.tcl
+"""
+import json, io, sys
+
+src = sys.argv[1]
+dst = sys.argv[2] if len(sys.argv) > 2 else 'fixture_on.json'
+d = json.load(io.open(src, encoding='utf-8'))
+player = next(a for a in d['assets'] if a['type'] == 'msx2player')
+params = {"digKey": 1, "hitsPerTile": 2, "digCooldown": 8,
+          "requireKeyRelease": False, "destroyedLimit": 64, "digSound": True}
+for key in ('player', 'compact'):
+    node = player['data'].get(key)
+    if isinstance(node, dict):
+        skills = node.setdefault('activeSkills', [])
+        if 'destroy_tile' not in skills:
+            skills.append('destroy_tile')
+        node.setdefault('skillParameters', {})['destroy_tile'] = params
+marked = 0
+for asset in d['assets']:
+    if asset['type'] != 'msx2bitmaproom':
+        continue
+    for entry in (asset['data'].get('atlas') or {}).get('entries', []):
+        entry['destructible'] = True
+        marked += 1
+json.dump(d, io.open(dst, 'w', encoding='utf-8'))
+print(f'{dst}: destroy_tile enabled, {marked} atlas entries marked destructible')

--- a/types.ts
+++ b/types.ts
@@ -750,6 +750,19 @@ export interface Msx2PlayerDefinition {
     spriteSize: Msx2PlayerSpriteSize;
     paletteAssetId?: string;
     usesFlipX: boolean;
+    /**
+     * Optional sprite asset used for the destroy_tile skill's debris chips.
+     * When omitted the generator falls back to a sprite named /debris|viruta/i,
+     * then to its built-in 3x3 grey chip. Consumed by resolveBitmapDebrisSprite.
+     */
+    debrisSpriteAssetId?: string;
+    /**
+     * Explicit per-animation-state sprite overrides (state name -> sprite asset
+     * id) for SCREEN 5 bitmap rooms. Wins over the Player Animations table.
+     * e.g. { digging: 'pick_swing_sprite' }. Consumed by
+     * resolveBitmapRoomStateAnimations.
+     */
+    stateSprites?: Record<string, string>;
   };
   animations: Record<string, Msx2PlayerAnimation>;
   /** Stable row order for the animation table and MSX export. */

--- a/types.ts
+++ b/types.ts
@@ -406,6 +406,8 @@ export interface Msx2BitmapRoomAtlasEntry {
   collisionFlags?: number;
   /** Optional SCREEN 5 bitmap-room behavior code applied when this atlas tile is painted. 3 = ice_slide surface. */
   behaviorCode?: number;
+  /** SCREEN 5 bitmap-room destroy_tile skill: cells painted with this tile can be dug out by the player. */
+  destructible?: boolean;
 }
 
 /**

--- a/utils/msx2PlatformPhysics.ts
+++ b/utils/msx2PlatformPhysics.ts
@@ -138,6 +138,21 @@ export interface Msx2CrouchConfig {
 }
 
 /**
+ * Destroy-tile (dig) skill config for SCREEN 5 bitmap rooms. `digKey` is a
+ * keyboard selector index (0=SPACE 1=B 2=N 3=Z 4=X 5=M) resolved to a PPI
+ * matrix row/mask by the ASM generator.
+ */
+export interface Msx2DestroyTileConfig {
+  enabled: boolean;
+  digKey: number;
+  hitsPerTile: number;
+  digCooldown: number;
+  requireKeyRelease: boolean;
+  destroyedLimit: number;
+  digSound: boolean;
+}
+
+/**
  * Perception skill config (MSX2 SCREEN 5 bitmap rooms).
  *
  * Passive skill: no input binding. Every frame the runtime measures the
@@ -819,6 +834,31 @@ export function getMsx2CrouchConfigFromPlayerEntity(player: any | undefined): Ms
     crouchSpeed: Math.max(0, Math.min(4, Math.trunc(crouchSpeed))),
     crouchHitboxHeight: Math.max(4, Math.min(12, Math.trunc(crouchHitboxHeight || 8))),
     slideDistance: Math.max(0, Math.min(16, Math.trunc(slideDistance))),
+  };
+}
+
+/**
+ * Returns the resolved destroy_tile (dig) skill config for the given player.
+ *
+ * Reads `player.skillParameters.destroy_tile` and clamps every value to the
+ * ranges declared in `destroyTileParameters` (handlers/index.ts).
+ */
+export function getMsx2DestroyTileConfigFromPlayerEntity(player: any | undefined): Msx2DestroyTileConfig {
+  const activeSkills = readPlayerActiveSkills(player);
+  const enabled = activeSkills.includes('destroy_tile');
+  const params = (player?.skillParameters?.destroy_tile || {}) as Record<string, number | boolean>;
+  const digKey = pickSkillNumberParam(params, 'destroy_tile', ['digKey'], 1);
+  const hitsPerTile = pickSkillNumberParam(params, 'destroy_tile', ['hitsPerTile'], 3);
+  const digCooldown = pickSkillNumberParam(params, 'destroy_tile', ['digCooldown'], 12);
+  const destroyedLimit = pickSkillNumberParam(params, 'destroy_tile', ['destroyedLimit'], 64);
+  return {
+    enabled,
+    digKey: Math.max(0, Math.min(5, Math.trunc(digKey))),
+    hitsPerTile: Math.max(1, Math.min(8, Math.trunc(hitsPerTile || 3))),
+    digCooldown: Math.max(4, Math.min(60, Math.trunc(digCooldown || 12))),
+    requireKeyRelease: params.requireKeyRelease === true,
+    destroyedLimit: Math.max(16, Math.min(128, Math.trunc(destroyedLimit || 64))),
+    digSound: params.digSound !== false,
   };
 }
 

--- a/utils/msxGenerator/generators/msx2/msx2BitmapDestroyTileGenerator.ts
+++ b/utils/msxGenerator/generators/msx2/msx2BitmapDestroyTileGenerator.ts
@@ -1,0 +1,851 @@
+import { Msx2DestroyTileConfig } from '../../../msx2PlatformPhysics';
+
+/**
+ * SCREEN 5 bitmap-room DESTROY TILE (dig) skill — Terraria-style picking.
+ *
+ * On the configurable dig key, the player swings a pick at the wall directly
+ * ahead (facing direction). The TOP body cell is probed first, then the BOTTOM
+ * one (a 16x32 two-sprite player digs its upper front tile before the lower
+ * one; a 16x16 player has a single front cell). A cell reacts only when it is
+ * SOLID in the collision map AND painted with an atlas tile marked
+ * "Destructible" in the SCREEN 5 screen editor (per-room ROM bitmask).
+ *
+ * Every connected swing spawns debris chips (hardware sprites, ~1 second of
+ * scatter with gravity) and plays an optional PSG thud. After `hitsPerTile`
+ * swings on the same cell the tile dissolves: HMMV fills the 16x16 cell with
+ * the room background colour on the displayed page, the collision cell flips
+ * to no-solid (and the behavior cell clears), and the (room, cell) pair is
+ * appended to a persistence list. The list is re-applied after every room
+ * composition (boot, edge transition, dialogue repaint), so holes survive
+ * leaving and re-entering the screen. Compressed/banked room data is never
+ * touched: rooms compose from ROM as authored and the holes are re-punched
+ * on top, exactly like the collector-gems overlay.
+ *
+ * Per-frame cost when idle: one key read + two cooldown ticks (~90 cycles).
+ * The debris pool only iterates when chips are alive; the HMMV fill runs on
+ * the V9938 command engine (async), so the 60 fps main loop is preserved.
+ *
+ * RAM: fixed region at `ramBase` (#C2D0, above the behavior map + the shared
+ * #C2C0 command scratch, far below the BIOS stack):
+ *   +0  cooldown          frames until the next swing
+ *   +1  lock              requireKeyRelease latch
+ *   +2  target            cell index being picked (#FF = none)
+ *   +3  hits              swings landed on the target
+ *   +4  anim              frames left asserting the 'digging' anim state
+ *   +5  count             persisted destroyed-tile entries
+ *   +6  page              target page for the HMMV fill (0/1)
+ *   +7  debris pool       4 slots x 5 bytes (ttl, x, y, vx, vy)
+ *   +27 destroyed list    destroyedLimit x 2 bytes (room, cell)
+ */
+
+export const MSX2_BITMAP_DESTROY_DEBRIS_SLOTS = 4;
+const DEBRIS_STRIDE = 5;
+const DEBRIS_TTL = 60;            // ~1 second at 60 fps
+const DEBRIS_HIDDEN_SPRITE_Y = 0xd4; // same off-screen non-terminator Y as enemies/foreground
+
+/** digKey selector -> PPI keyboard matrix (row, pressed-bit mask). */
+const DIG_KEYS: Array<{ row: number; mask: number; label: string }> = [
+  { row: 8, mask: 0x01, label: 'SPACE' },
+  { row: 2, mask: 0x80, label: 'B' },
+  { row: 4, mask: 0x08, label: 'N' },
+  { row: 5, mask: 0x80, label: 'Z' },
+  { row: 5, mask: 0x20, label: 'X' },
+  { row: 4, mask: 0x04, label: 'M' },
+];
+
+function asmByte(value: number): string {
+  return `#${(value & 0xff).toString(16).toUpperCase().padStart(2, '0')}`;
+}
+
+function asmWord(value: number): string {
+  return `#${Math.max(0, Math.min(0xffff, Math.floor(value))).toString(16).toUpperCase().padStart(4, '0')}`;
+}
+
+export interface BitmapDestroyTilePlayerHitbox { x: number; y: number; w: number; h: number; }
+
+export interface BitmapDestroyTileOptions {
+  /** Fixed RAM base for the whole destroy-tile state (see module header). */
+  ramBase: number;
+  hitbox: BitmapDestroyTilePlayerHitbox;
+  /** player_anim_state clip id for the 'digging' animation row (undefined = no state sprite authored). */
+  digAnimId?: number;
+  /** Sprite pattern NUMBER (group*4) reserved for the debris chip. */
+  debrisPatternNumber: number;
+  /** VRAM address of the first debris SAT slot (after carry, before bullets). */
+  debrisSatBase: number;
+  /** VRAM address of the first debris sprite line-colour table. */
+  debrisColorBase: number;
+  /** HUD band offset added to sprite Y (BITMAP_ROOM_GAME_Y_OFFSET). */
+  gameYOffset: number;
+  /** Per-room 24-byte destructible-cell bitmask (bit set = cell can be dug). */
+  destructibleMasks: number[][];
+  /** Per-room HMMV colour byte ((bg<<4)|bg) used to dissolve cells. */
+  bgColorBytes: number[];
+}
+
+export interface BitmapDestroyDebrisSprite {
+  patternBytes: number[]; // 32 bytes, 16x16 mode-2 quadrants
+  colorBytes: number[];   // 16 bytes, per-line colours
+}
+
+export function bitmapDestroyTileEnabled(config: Msx2DestroyTileConfig | undefined): boolean {
+  return Boolean(config?.enabled);
+}
+
+export function bitmapDestroyTileRamBytes(config: Msx2DestroyTileConfig | undefined): number {
+  if (!bitmapDestroyTileEnabled(config)) return 0;
+  return 7 + MSX2_BITMAP_DESTROY_DEBRIS_SLOTS * DEBRIS_STRIDE + config!.destroyedLimit * 2;
+}
+
+export function buildBitmapDestroyTileEquates(
+  config: Msx2DestroyTileConfig | undefined,
+  opts: BitmapDestroyTileOptions,
+): string {
+  if (!bitmapDestroyTileEnabled(config)) return '';
+  const base = opts.ramBase;
+  const listBase = base + 7 + MSX2_BITMAP_DESTROY_DEBRIS_SLOTS * DEBRIS_STRIDE;
+  return `; --- DESTROY TILE (dig) skill RAM (${bitmapDestroyTileRamBytes(config)} bytes at ${asmWord(base)}) ---
+; Fixed region above the behavior map / #C2C0 command scratch; NOT part of the
+; sub-#C1F0 skill chain (the persistence list would not fit there).
+bitmap_destroy_cooldown  EQU ${asmWord(base)}
+bitmap_destroy_lock      EQU ${asmWord(base + 1)}
+bitmap_destroy_target    EQU ${asmWord(base + 2)}
+bitmap_destroy_hits      EQU ${asmWord(base + 3)}
+bitmap_destroy_anim      EQU ${asmWord(base + 4)}
+bitmap_destroy_count     EQU ${asmWord(base + 5)}
+bitmap_destroy_page      EQU ${asmWord(base + 6)}
+bitmap_destroy_debris    EQU ${asmWord(base + 7)}
+bitmap_destroy_list      EQU ${asmWord(listBase)}
+bitmap_destroy_cmd_block EQU #C2C0
+`;
+}
+
+export function buildBitmapDestroyTileInitClearAsm(config: Msx2DestroyTileConfig | undefined): string {
+  if (!bitmapDestroyTileEnabled(config)) return '';
+  const debrisClears = Array.from({ length: MSX2_BITMAP_DESTROY_DEBRIS_SLOTS }, (_u, i) =>
+    `    ld (bitmap_destroy_debris + ${i * DEBRIS_STRIDE}), a`).join('\n');
+  return `    ; destroy_tile: fresh game -> no cooldown, no target, empty destroyed list.
+    xor a
+    ld (bitmap_destroy_cooldown), a
+    ld (bitmap_destroy_lock), a
+    ld (bitmap_destroy_hits), a
+    ld (bitmap_destroy_anim), a
+    ld (bitmap_destroy_count), a
+    ld (bitmap_destroy_page), a
+${debrisClears}
+    dec a
+    ld (bitmap_destroy_target), a
+`;
+}
+
+/** Main-loop gate after update_player_movement: debris step + dig input. */
+export function buildBitmapDestroyTileGateAsm(config: Msx2DestroyTileConfig | undefined): string {
+  if (!bitmapDestroyTileEnabled(config)) return '';
+  return '    call bitmap_destroy_update\n';
+}
+
+/** SAT chain call (placed BEFORE the shoot bullet writer, like carry). */
+export function buildBitmapDestroyTileSatCallAsm(config: Msx2DestroyTileConfig | undefined): string {
+  if (!bitmapDestroyTileEnabled(config)) return '';
+  return '    call bitmap_destroy_update_debris_sat\n';
+}
+
+/** Re-punch destroyed holes on the visible page (boot + dialogue/perception repaints). */
+export function buildBitmapDestroyTileApplyVisibleCallAsm(config: Msx2DestroyTileConfig | undefined): string {
+  if (!bitmapDestroyTileEnabled(config)) return '';
+  return '    call bitmap_destroy_apply_visible    ; re-punch destroyed tiles on current page\n';
+}
+
+/** Re-punch destroyed holes on the hidden page before commit_room_flip publishes it. */
+export function buildBitmapDestroyTileApplyPendingCallAsm(config: Msx2DestroyTileConfig | undefined): string {
+  if (!bitmapDestroyTileEnabled(config)) return '';
+  return '    call bitmap_destroy_apply_pending    ; re-punch destroyed tiles on hidden page before flip\n';
+}
+
+/** Boot-time upload of the debris chip pattern + the 4 debris slot colour tables. */
+export function buildBitmapDestroyTileInitUploadAsm(
+  config: Msx2DestroyTileConfig | undefined,
+  opts: BitmapDestroyTileOptions,
+): string {
+  if (!bitmapDestroyTileEnabled(config)) return '';
+  const patternVram = 0xf800 + opts.debrisPatternNumber * 8;
+  const colorUploads = Array.from({ length: MSX2_BITMAP_DESTROY_DEBRIS_SLOTS }, (_u, i) => {
+    const colorVram = opts.debrisColorBase + i * 16;
+    return `    ld hl, bitmap_destroy_chip_color_data
+    ld de, ${asmWord(colorVram)}
+    ld bc, bitmap_destroy_chip_color_data_end - bitmap_destroy_chip_color_data
+    call copy_to_vram_ext
+`;
+  }).join('');
+  return `    ; destroy_tile: debris chip pattern (32 bytes) -> VRAM ${asmWord(patternVram)} + 4 slot colour tables
+    ld hl, bitmap_destroy_chip_pattern_data
+    ld de, ${asmWord(patternVram)}
+    ld bc, bitmap_destroy_chip_pattern_data_end - bitmap_destroy_chip_pattern_data
+    call copy_to_vram_ext
+${colorUploads}`;
+}
+
+/** ROM data: per-room destructible masks, bg colours, chip sprite, velocities, sfx. */
+export function buildBitmapDestroyTileDataAsm(
+  config: Msx2DestroyTileConfig | undefined,
+  opts: BitmapDestroyTileOptions,
+  sprite: BitmapDestroyDebrisSprite | undefined,
+): string {
+  if (!bitmapDestroyTileEnabled(config)) return '';
+  // Built-in fallback chip: a 3x3 pixel nugget in the top-left corner of the
+  // 16x16 sprite (mode 2 quadrant layout: bytes 0..15 = left column rows 0..15).
+  const fallbackPattern = Array(32).fill(0);
+  fallbackPattern[0] = 0xe0;
+  fallbackPattern[1] = 0xe0;
+  fallbackPattern[2] = 0xe0;
+  const pattern = sprite?.patternBytes && sprite.patternBytes.length === 32
+    ? sprite.patternBytes
+    : fallbackPattern;
+  const colors = sprite?.colorBytes && sprite.colorBytes.length === 16
+    ? sprite.colorBytes
+    : Array(16).fill(14);
+  const emit = (label: string, bytes: number[], comment: string): string => {
+    const lines: string[] = [`; ${comment}`, `${label}:`];
+    for (let i = 0; i < bytes.length; i += 16) {
+      lines.push(`    DB ${bytes.slice(i, i + 16).map(b => asmByte(b)).join(',')}`);
+    }
+    lines.push(`${label}_end:`);
+    return lines.join('\n') + '\n';
+  };
+  const maskRows = opts.destructibleMasks.map((mask, roomIndex) =>
+    emit(`bitmap_destroy_mask_room_${roomIndex}`, mask, `Room ${roomIndex} destructible cells (192 cells / 8 = 24 bytes, bit = cell & 7)`)
+  ).join('');
+  const sfxData = config!.digSound
+    ? `; destroy_tile pick thud: PSG register/value pairs (mixer, period A #1E0, envelope decay)
+bitmap_destroy_sfx_data:
+    db 7,#3E,0,#E0,1,#01,11,#38,12,#00,8,#10,13,#09
+`
+    : '';
+  return `${maskRows}bitmap_destroy_mask_ptrs:
+${opts.destructibleMasks.map((_m, i) => `    DW bitmap_destroy_mask_room_${i}`).join('\n')}
+; Per-room HMMV colour byte ((bg<<4)|bg) used when a tile dissolves.
+bitmap_destroy_bg_table:
+    DB ${opts.bgColorBytes.map(b => asmByte(b)).join(',')}
+bitmap_destroy_bit_table:
+    DB #01,#02,#04,#08,#10,#20,#40,#80
+; Debris chip velocities per pool slot: vx, vy (signed px/frame; vy gains
+; +1 every 4 frames until +3, so chips arc apart and rain down in ~1 second).
+bitmap_destroy_vel_table:
+    DB #FE,#FD, #02,#FD, #FF,#FE, #01,#FE
+${emit('bitmap_destroy_chip_pattern_data', pattern, 'destroy_tile: 16x16 debris chip sprite pattern (mode 2 quadrants)')}${emit('bitmap_destroy_chip_color_data', colors, 'destroy_tile: 16-byte line colour table for the debris chip')}${sfxData}`;
+}
+
+/** The full destroy_tile runtime. Empty when the skill is disabled. */
+export function buildBitmapDestroyTileRuntimeAsm(
+  config: Msx2DestroyTileConfig | undefined,
+  opts: BitmapDestroyTileOptions,
+): string {
+  if (!config || !bitmapDestroyTileEnabled(config)) return '';
+
+  const key = DIG_KEYS[Math.max(0, Math.min(DIG_KEYS.length - 1, config.digKey))];
+  const cooldown = Math.max(4, Math.min(60, config.digCooldown));
+  const hitsPerTile = Math.max(1, Math.min(8, config.hitsPerTile));
+  const animFrames = Math.min(cooldown, 12);
+  const limit = Math.max(16, Math.min(128, config.destroyedLimit));
+  const hb = opts.hitbox;
+  const rightProbeAdd = Math.max(1, Math.min(48, hb.x + hb.w)); // first pixel beyond the right edge
+  const leftDelta = hb.x - 1;                                    // pixel just left of the left edge
+  const topOffset = Math.max(0, Math.min(31, hb.y));
+  const bottomOffset = Math.max(0, Math.min(47, hb.y + hb.h - 1));
+  const gameYOffset = asmByte(opts.gameYOffset);
+  const patternNumber = asmByte(opts.debrisPatternNumber);
+  const satBase = asmWord(opts.debrisSatBase);
+
+  const animAssert = typeof opts.digAnimId === 'number'
+    ? `    ld a, ${opts.digAnimId}
+    ld (player_anim_state), a    ; assert the 'digging' clip while the swing plays
+`
+    : '';
+  const lockGate = config.requireKeyRelease
+    ? `    ld a, (bitmap_destroy_lock)
+    or a
+    ret nz
+    ld a, 1
+    ld (bitmap_destroy_lock), a
+`
+    : '';
+  const sfxCall = config.digSound ? `    call bitmap_destroy_sfx
+` : '';
+  const sfxRoutine = config.digSound
+    ? `
+; ------------------------------------------------------------
+; FUNCTION: bitmap_destroy_sfx
+; ------------------------------------------------------------
+; PURPOSE: pick-hit PSG thud (fire-and-forget register writes, no per-frame
+;   engine; same pattern as the gem blip but a lower square tone).
+; DESTROYS: AF, B, HL. PRESERVES: C, DE, IX, IY.
+; ------------------------------------------------------------
+bitmap_destroy_sfx:
+    ld hl, bitmap_destroy_sfx_data
+    ld b, 7
+.dsfx_loop:
+    ld a, (hl)
+    out (#A0), a
+    inc hl
+    ld a, (hl)
+    out (#A1), a
+    inc hl
+    djnz .dsfx_loop
+    ret
+`
+    : '';
+
+  const leftProbeAsm = leftDelta < 0
+    ? `    ld a, (player_x)
+    sub ${-leftDelta}
+    jp c, .dig_done          ; already at the room's left edge
+`
+    : `    ld a, (player_x)
+    add a, ${leftDelta}
+`;
+
+  return `
+; ------------------------------------------------------------
+; FUNCTION: bitmap_destroy_key_pressed
+; ------------------------------------------------------------
+; PURPOSE: reads the dig key ('${key.label}', keyboard matrix row ${key.row} mask ${asmByte(key.mask)}) via PPI.
+; OUTPUT: A = 1 when pressed (NZ), A = 0 otherwise (Z).
+; DESTROYS: AF. PRESERVES: BC, DE, HL, IX, IY.
+; ------------------------------------------------------------
+bitmap_destroy_key_pressed:
+    in a, (PPI_C)
+    and #F0
+    or ${key.row}
+    out (PPI_C), a
+    in a, (PPI_B)
+    cpl
+    and ${asmByte(key.mask)}
+    ret z
+    ld a, 1
+    ret
+
+; ------------------------------------------------------------
+; FUNCTION: bitmap_destroy_update
+; ------------------------------------------------------------
+; PURPOSE:
+;   Per-frame destroy_tile driver: steps the debris chips, keeps the
+;   'digging' animation asserted while a swing plays, ticks the swing
+;   cooldown and, on the dig key, picks the destructible cell ahead
+;   (top body cell first, then the bottom one).
+;
+; INPUT: player_x/player_y/player_facing, bitmap_room_collision_map,
+;   bitmap_destroy_* state.
+; DESTROYS: AF, BC, DE, HL, IX. PRESERVES: IY.
+; ------------------------------------------------------------
+bitmap_destroy_update:
+    call bitmap_destroy_step_debris
+    ; 'digging' pose while the swing timer runs.
+    ld a, (bitmap_destroy_anim)
+    or a
+    jp z, .dig_no_anim
+    dec a
+    ld (bitmap_destroy_anim), a
+${animAssert}.dig_no_anim:
+    ; Swing cooldown tick.
+    ld a, (bitmap_destroy_cooldown)
+    or a
+    jp z, .dig_cool_ready
+    dec a
+    ld (bitmap_destroy_cooldown), a
+.dig_cool_ready:
+    call bitmap_destroy_key_pressed
+    or a
+    jp nz, .dig_pressed
+    xor a
+    ld (bitmap_destroy_lock), a
+    ret
+.dig_pressed:
+    ld a, (bitmap_destroy_cooldown)
+    or a
+    ret nz
+${lockGate}    ; Front column: probe one pixel beyond the facing edge of the hitbox.
+    ld a, (player_facing)
+    or a
+    jp z, .dig_face_left
+    ld a, (player_x)
+    add a, ${rightProbeAdd}
+    jp c, .dig_done          ; past the right edge of the room
+    jp .dig_col_ready
+.dig_face_left:
+${leftProbeAsm}.dig_col_ready:
+    srl a
+    srl a
+    srl a
+    srl a
+    ld e, a                  ; E = front column (0..15)
+    ; Candidate 1: TOP body cell ("primer el tile superior/davant").
+    ld a, (player_y)
+${topOffset > 0 ? `    add a, ${topOffset}\n` : ''}    srl a
+    srl a
+    srl a
+    srl a
+    ld d, a                  ; D = top row
+    call bitmap_destroy_try_cell
+    ret c                    ; swing landed
+    ; Candidate 2: BOTTOM body cell (only when it is a different row).
+    ld a, (player_y)
+    add a, ${bottomOffset}
+    srl a
+    srl a
+    srl a
+    srl a
+    cp d
+    ret z                    ; same cell already probed
+    ld d, a
+    jp bitmap_destroy_try_cell
+.dig_done:
+    ret
+
+; ------------------------------------------------------------
+; FUNCTION: bitmap_destroy_try_cell
+; ------------------------------------------------------------
+; PURPOSE:
+;   Swing at cell (row D, column E). Lands only on a SOLID collision cell
+;   whose atlas tile is marked destructible. Tracks the multi-hit target;
+;   after ${hitsPerTile} hit(s) the tile dissolves (HMMV background fill on the
+;   displayed page + collision/behavior cleared + persistence entry).
+;
+; INPUT: D = row, E = column. OUTPUT: carry SET when the swing landed.
+; DESTROYS: AF, BC, DE, HL, IX. PRESERVES: IY.
+; ------------------------------------------------------------
+bitmap_destroy_try_cell:
+    ld a, d
+    cp 12
+    jp nc, .dtc_miss
+    ; C = cell index = row*16 + column.
+    ld a, d
+    add a, a
+    add a, a
+    add a, a
+    add a, a
+    add a, e
+    ld c, a
+    ; Solid?
+    ld hl, bitmap_room_collision_map
+    ld b, 0
+    add hl, bc
+    ld a, (hl)
+    or a
+    jp z, .dtc_miss
+    ; Destructible in this room's mask?
+    push hl
+    ld a, c
+    call bitmap_destroy_cell_flag
+    pop hl
+    jp z, .dtc_miss
+    ; ---- swing landed ----
+    ld a, ${cooldown}
+    ld (bitmap_destroy_cooldown), a
+    ld a, ${animFrames}
+    ld (bitmap_destroy_anim), a
+${sfxCall}    ; Multi-hit target tracking (switching cells restarts the count).
+    ld a, (bitmap_destroy_target)
+    cp c
+    jp z, .dtc_same_target
+    ld a, c
+    ld (bitmap_destroy_target), a
+    ld a, 1
+    jp .dtc_store_hits
+.dtc_same_target:
+    ld a, (bitmap_destroy_hits)
+    inc a
+.dtc_store_hits:
+    ld (bitmap_destroy_hits), a
+    cp ${hitsPerTile}
+    jp nc, .dtc_destroy
+    ; Partial hit: sparks only (2 chips).
+    push hl
+    ld b, 2
+    call bitmap_destroy_spawn_debris
+    pop hl
+    scf
+    ret
+.dtc_destroy:
+    ; Dissolve: collision + behavior cells to 0 (HL still points at the cell).
+    xor a
+    ld (hl), a
+    ld hl, bitmap_room_behavior_map
+    ld b, 0
+    add hl, bc
+    ld (hl), a
+    ld (bitmap_destroy_hits), a
+    dec a
+    ld (bitmap_destroy_target), a
+    ; Visual fill on the currently displayed page.
+    ld a, (bitmap_displayed_page)
+    ld (bitmap_destroy_page), a
+    push bc
+    call bitmap_destroy_fill_cell
+    pop bc
+    ; Persist (room, cell) so the hole is re-punched on every room compose.
+    ld a, (bitmap_destroy_count)
+    cp ${limit}
+    jp nc, .dtc_burst        ; list full: hole is visual-only for this visit
+    ld l, a
+    ld h, 0
+    add hl, hl
+    ld de, bitmap_destroy_list
+    add hl, de
+    ld a, (current_screen_index)
+    ld (hl), a
+    inc hl
+    ld (hl), c
+    ld a, (bitmap_destroy_count)
+    inc a
+    ld (bitmap_destroy_count), a
+.dtc_burst:
+    ld b, ${MSX2_BITMAP_DESTROY_DEBRIS_SLOTS}
+    call bitmap_destroy_spawn_debris
+    scf
+    ret
+.dtc_miss:
+    or a
+    ret
+
+; ------------------------------------------------------------
+; FUNCTION: bitmap_destroy_cell_flag
+; ------------------------------------------------------------
+; PURPOSE: test the current room's destructible bitmask for one cell.
+; INPUT: A = cell index (0..191). OUTPUT: NZ when destructible.
+; DESTROYS: AF, DE, HL. PRESERVES: BC, IX, IY.
+; ------------------------------------------------------------
+bitmap_destroy_cell_flag:
+    ld e, a
+    ld d, 0
+    push de                  ; save cell
+    ld a, (current_screen_index)
+    ld e, a
+    ld hl, bitmap_destroy_mask_ptrs
+    add hl, de
+    add hl, de
+    ld a, (hl)
+    inc hl
+    ld h, (hl)
+    ld l, a                  ; HL = room mask base
+    pop de                   ; DE = cell
+    ld a, e
+    and 7
+    push de
+    push hl
+    ld e, a
+    ld hl, bitmap_destroy_bit_table
+    add hl, de
+    ld a, (hl)               ; A = bit mask for (cell & 7)
+    pop hl
+    pop de
+    srl e
+    srl e
+    srl e                    ; DE = cell >> 3 (byte index, D stays 0)
+    add hl, de
+    and (hl)
+    ret
+
+; ------------------------------------------------------------
+; FUNCTION: bitmap_destroy_fill_cell
+; ------------------------------------------------------------
+; PURPOSE:
+;   Build + launch an HMMV that fills cell C with the room background colour
+;   on page bitmap_destroy_page. 15-byte block in the shared #C2C0 scratch
+;   (all launches in this engine are sequential in the main loop).
+;
+; INPUT: C = cell index, bitmap_destroy_page = 0/1.
+; DESTROYS: AF, B, DE, HL. PRESERVES: C, IX, IY.
+; SIDE EFFECTS: waits for the previous VDP command; restores R#15 = S#0.
+; ------------------------------------------------------------
+bitmap_destroy_fill_cell:
+    ld hl, bitmap_destroy_cmd_block
+    xor a
+    ld b, 4                  ; SX (2) + SY (2) = 0 (unused by HMMV)
+.dfc_zero:
+    ld (hl), a
+    inc hl
+    djnz .dfc_zero
+    ld a, c
+    and #0F
+    add a, a
+    add a, a
+    add a, a
+    add a, a
+    ld (hl), a               ; DX low = (cell & 15) * 16
+    inc hl
+    xor a
+    ld (hl), a               ; DX high
+    inc hl
+    ld a, c
+    and #F0                  ; (cell >> 4) * 16 in one mask
+    add a, ${gameYOffset}
+    ld (hl), a               ; DY low = row*16 + HUD band offset
+    inc hl
+    ld a, (bitmap_destroy_page)
+    ld (hl), a               ; DY high = page (0 -> Y 0..255, 1 -> Y 256..511)
+    inc hl
+    ld a, 16
+    ld (hl), a               ; NX = 16
+    inc hl
+    xor a
+    ld (hl), a
+    inc hl
+    ld a, 16
+    ld (hl), a               ; NY = 16
+    inc hl
+    xor a
+    ld (hl), a
+    inc hl
+    ld a, (current_screen_index)
+    ld e, a
+    ld d, 0
+    push hl
+    ld hl, bitmap_destroy_bg_table
+    add hl, de
+    ld a, (hl)
+    pop hl
+    ld (hl), a               ; CLR = (bg<<4)|bg
+    inc hl
+    xor a
+    ld (hl), a               ; ARG
+    inc hl
+    ld a, #C0
+    ld (hl), a               ; CMD = HMMV
+    call vdp_wait_cmd_ready
+    call vdp_reinit_cmd_pointer
+    ld hl, bitmap_destroy_cmd_block
+    ld b, 15
+.dfc_launch:
+    ld a, (hl)
+    out (VDP_CMD_PORT), a
+    inc hl
+    djnz .dfc_launch
+    ld a, #0F
+    ld e, #00
+    jp vdp_write_register
+
+; ------------------------------------------------------------
+; FUNCTION: bitmap_destroy_spawn_debris
+; ------------------------------------------------------------
+; PURPOSE: activate up to B debris chips at the centre of cell C, each free
+;   pool slot taking the next velocity pair from the table.
+; INPUT: B = chips to spawn, C = cell index.
+; DESTROYS: AF, B, DE, HL, IX. PRESERVES: C, IY.
+; ------------------------------------------------------------
+bitmap_destroy_spawn_debris:
+    ld a, c
+    and #0F
+    add a, a
+    add a, a
+    add a, a
+    add a, a
+    add a, 4
+    ld d, a                  ; D = chip x (cell centre-ish)
+    ld a, c
+    and #F0
+    add a, 4
+    ld e, a                  ; E = chip y
+    ld ix, bitmap_destroy_debris
+    ld hl, bitmap_destroy_vel_table
+    push bc
+    ld c, ${MSX2_BITMAP_DESTROY_DEBRIS_SLOTS}
+.dsp_loop:
+    ld a, (ix+0)
+    or a
+    jp nz, .dsp_next
+    ld a, ${DEBRIS_TTL}
+    ld (ix+0), a
+    ld (ix+1), d
+    ld (ix+2), e
+    ld a, (hl)
+    ld (ix+3), a
+    inc hl
+    ld a, (hl)
+    ld (ix+4), a
+    dec hl
+    dec b
+    jp z, .dsp_done
+.dsp_next:
+    inc ix
+    inc ix
+    inc ix
+    inc ix
+    inc ix
+    inc hl
+    inc hl
+    dec c
+    jp nz, .dsp_loop
+.dsp_done:
+    pop bc
+    ret
+
+; ------------------------------------------------------------
+; FUNCTION: bitmap_destroy_step_debris
+; ------------------------------------------------------------
+; PURPOSE: advance live debris chips: x += vx every frame, vy gains +1 every
+;   4 frames (capped at +3), y += vy; chips die on ttl 0 or leaving the band.
+; DESTROYS: AF, B, IX. PRESERVES: C, DE, HL, IY.
+; ------------------------------------------------------------
+bitmap_destroy_step_debris:
+    ld ix, bitmap_destroy_debris
+    ld b, ${MSX2_BITMAP_DESTROY_DEBRIS_SLOTS}
+.dst_loop:
+    ld a, (ix+0)
+    or a
+    jp z, .dst_next
+    dec a
+    ld (ix+0), a
+    jp z, .dst_next          ; expired this frame
+    ld a, (ix+1)
+    add a, (ix+3)
+    ld (ix+1), a
+    ld a, (ix+0)
+    and 3
+    jp nz, .dst_fall
+    ld a, (ix+4)
+    cp 3
+    jp z, .dst_fall
+    inc a
+    ld (ix+4), a
+.dst_fall:
+    ld a, (ix+2)
+    add a, (ix+4)
+    ld (ix+2), a
+    cp 192
+    jp c, .dst_next
+    xor a                    ; fell below the band (or wrapped above): kill
+    ld (ix+0), a
+.dst_next:
+    inc ix
+    inc ix
+    inc ix
+    inc ix
+    inc ix
+    djnz .dst_loop
+    ret
+
+; ------------------------------------------------------------
+; FUNCTION: bitmap_destroy_update_debris_sat
+; ------------------------------------------------------------
+; PURPOSE: write the ${MSX2_BITMAP_DESTROY_DEBRIS_SLOTS} debris SAT slots (hidden chips park at Y ${asmByte(DEBRIS_HIDDEN_SPRITE_Y)},
+;   the same off-screen non-terminator Y the other systems use) plus a #D8
+;   terminator; when shoot is active its bullet writer runs after this one
+;   and overwrites the terminator with the first bullet slot.
+; OUTPUT: SAT entries at VRAM ${satBase} onwards.
+; DESTROYS: AF, DE, HL, IX. PRESERVES: BC (saved), IY.
+; ------------------------------------------------------------
+bitmap_destroy_update_debris_sat:
+    ld de, ${satBase}
+    push bc
+    push de
+    ld a, d
+    and #C0
+    rlca
+    rlca
+    ld e, a
+    ld a, #0E
+    call vdp_write_register
+    pop de
+    ld a, e
+    out (VDP_CTRL_PORT), a
+    ld a, d
+    and #3F
+    or #40
+    out (VDP_CTRL_PORT), a
+    ld ix, bitmap_destroy_debris
+    ld b, ${MSX2_BITMAP_DESTROY_DEBRIS_SLOTS}
+.dsat_loop:
+    ld a, (ix+0)
+    or a
+    jp z, .dsat_hidden
+    ld a, (ix+2)
+    add a, ${gameYOffset}
+    out (VDP_DATA_PORT), a
+    ld a, (ix+1)
+    out (VDP_DATA_PORT), a
+    ld a, ${patternNumber}
+    out (VDP_DATA_PORT), a
+    xor a
+    out (VDP_DATA_PORT), a
+    jp .dsat_next
+.dsat_hidden:
+    ld a, ${asmByte(DEBRIS_HIDDEN_SPRITE_Y)}
+    out (VDP_DATA_PORT), a
+    xor a
+    out (VDP_DATA_PORT), a
+    out (VDP_DATA_PORT), a
+    out (VDP_DATA_PORT), a
+.dsat_next:
+    inc ix
+    inc ix
+    inc ix
+    inc ix
+    inc ix
+    djnz .dsat_loop
+    ld a, #D8
+    out (VDP_DATA_PORT), a
+    xor a
+    out (VDP_DATA_PORT), a
+    out (VDP_DATA_PORT), a
+    out (VDP_DATA_PORT), a
+    xor a
+    ld e, a
+    ld a, #0E
+    call vdp_write_register
+    pop bc
+    ret
+
+; ------------------------------------------------------------
+; FUNCTION: bitmap_destroy_apply_visible / bitmap_destroy_apply_pending
+; ------------------------------------------------------------
+; PURPOSE:
+;   Re-punch every destroyed tile of the CURRENT room: clear its collision +
+;   behavior cells (the room loaders just re-copied the pristine ROM grids)
+;   and HMMV-fill the cell on the target page. Runs at boot, on the hidden
+;   page inside commit_room_flip, and on dialogue/perception repaints. Also
+;   resets the in-progress swing target and despawns stale debris chips.
+;
+; DESTROYS: AF, BC, DE, HL. PRESERVES: IX, IY.
+; ------------------------------------------------------------
+bitmap_destroy_apply_visible:
+    ld a, (bitmap_displayed_page)
+    jp bitmap_destroy_apply_page
+bitmap_destroy_apply_pending:
+    ld a, (bitmap_pending_display_page)
+bitmap_destroy_apply_page:
+    ld (bitmap_destroy_page), a
+    ld a, #FF
+    ld (bitmap_destroy_target), a
+    xor a
+    ld (bitmap_destroy_hits), a
+    ld (bitmap_destroy_anim), a
+${Array.from({ length: MSX2_BITMAP_DESTROY_DEBRIS_SLOTS }, (_u, i) => `    ld (bitmap_destroy_debris + ${i * DEBRIS_STRIDE}), a`).join('\n')}
+    ld a, (bitmap_destroy_count)
+    or a
+    ret z
+    ld b, a
+    ld hl, bitmap_destroy_list
+.dap_loop:
+    ld a, (current_screen_index)
+    cp (hl)
+    inc hl
+    ld c, (hl)
+    inc hl
+    jp nz, .dap_next
+    push hl
+    push bc
+    ld hl, bitmap_room_collision_map
+    ld b, 0
+    add hl, bc
+    ld (hl), 0
+    ld hl, bitmap_room_behavior_map
+    add hl, bc
+    ld (hl), 0
+    call bitmap_destroy_fill_cell
+    pop bc
+    pop hl
+.dap_next:
+    djnz .dap_loop
+    ret
+${sfxRoutine}`;
+}

--- a/utils/msxGenerator/generators/msx2/msx2BitmapDestroyTileGenerator.ts
+++ b/utils/msxGenerator/generators/msx2/msx2BitmapDestroyTileGenerator.ts
@@ -248,8 +248,13 @@ export function buildBitmapDestroyTileRuntimeAsm(
   const animFrames = Math.min(cooldown, 12);
   const limit = Math.max(16, Math.min(128, config.destroyedLimit));
   const hb = opts.hitbox;
-  const rightProbeAdd = Math.max(1, Math.min(48, hb.x + hb.w)); // first pixel beyond the right edge
-  const leftDelta = hb.x - 1;                                    // pixel just left of the left edge
+  // Pick reach: 4px beyond the hitbox edge. The walk moves in 2px steps, so the
+  // player can stop up to 3px short of the cell boundary; probing just 1px past
+  // the edge then lands in the player's OWN column and the wall is never hit
+  // (caught by the OpenMSX smoke on a staircase wall). 4px still stays inside
+  // the adjacent 16px cell when the player is flush against it.
+  const rightProbeAdd = Math.max(1, Math.min(48, hb.x + hb.w + 3));
+  const leftDelta = hb.x - 4;
   const topOffset = Math.max(0, Math.min(31, hb.y));
   const bottomOffset = Math.max(0, Math.min(47, hb.y + hb.h - 1));
   const gameYOffset = asmByte(opts.gameYOffset);
@@ -269,7 +274,14 @@ export function buildBitmapDestroyTileRuntimeAsm(
     ld (bitmap_destroy_lock), a
 `
     : '';
-  const sfxCall = config.digSound ? `    call bitmap_destroy_sfx
+  // HL holds the collision-cell pointer across the hit path and the PSG sfx
+  // clobbers HL: without the push/pop the destroy step wrote its collision
+  // clear through a stale ROM address inside the Konami bank-switch window
+  // (#6000+), silently remapping the resident data bank instead of opening
+  // the cell (caught by the OpenMSX smoke).
+  const sfxCall = config.digSound ? `    push hl
+    call bitmap_destroy_sfx
+    pop hl
 ` : '';
   const sfxRoutine = config.digSound
     ? `

--- a/utils/msxGenerator/generators/msx2/msx2BitmapShootGenerator.ts
+++ b/utils/msxGenerator/generators/msx2/msx2BitmapShootGenerator.ts
@@ -61,6 +61,8 @@ export interface BitmapShootRuntimeOptions {
   platformSlotCount?: number;
   /** Carry-and-throw SAT slots reserved between platforms and the bullets. */
   carrySlotCount?: number;
+  /** destroy_tile debris SAT slots reserved between carry and the bullets. */
+  destroySlotCount?: number;
 }
 
 export interface BitmapShootSpriteData {
@@ -127,7 +129,7 @@ export function buildBitmapBulletInitUploadAsm(
   // first slot left the 2nd+ simultaneous bullets with an uninitialised (black)
   // colour table.
   const colorUploads = Array.from({ length: maxBullets }, (_unused, i) => {
-    const colorVram = opts.colorBase + (opts.playerLayerCount + (opts.enemySlotCount || 0) + (opts.platformSlotCount || 0) + (opts.carrySlotCount || 0) + i) * 16;
+    const colorVram = opts.colorBase + (opts.playerLayerCount + (opts.enemySlotCount || 0) + (opts.platformSlotCount || 0) + (opts.carrySlotCount || 0) + (opts.destroySlotCount || 0) + i) * 16;
     return `    ; bullet colour -> sprite slot ${opts.playerLayerCount + i} (VRAM ${asmWord(colorVram)})
     ld hl, bitmap_bullet_color_data
     ld de, ${asmWord(colorVram)}
@@ -179,7 +181,7 @@ export function buildBitmapShootRuntimeAsm(
   const shootCooldown = asmByte(Math.max(0, Math.min(120, Math.floor(config.shootCooldown) || 10)));
   const requireKeyRelease = config.requireKeyRelease !== false;
   const patternNumber = asmByte(opts.bulletPatternNumber);
-  const satStart = opts.satBase + ((opts.foregroundSlotCount || 0) + opts.playerLayerCount + (opts.enemySlotCount || 0) + (opts.platformSlotCount || 0) + (opts.carrySlotCount || 0)) * 4;
+  const satStart = opts.satBase + ((opts.foregroundSlotCount || 0) + opts.playerLayerCount + (opts.enemySlotCount || 0) + (opts.platformSlotCount || 0) + (opts.carrySlotCount || 0) + (opts.destroySlotCount || 0)) * 4;
   const gameYOffset = asmByte(opts.gameYOffset);
 
   const lockGate = requireKeyRelease

--- a/utils/msxGenerator/generators/msx2/msx2Screen5BitmapRoomGenerator.ts
+++ b/utils/msxGenerator/generators/msx2/msx2Screen5BitmapRoomGenerator.ts
@@ -2,7 +2,7 @@ import { ConnectionDirection, Msx2BitmapRoomCommand, Msx2GameFlowEndNode, Msx2Ga
 import { ProjectAnalysis } from '../../../asmTemplateGenerator';
 import { GeneratedASMFiles } from '../../types/asmTypes';
 import type { MSXMapperFormat, MSXRomMode } from '../../index';
-import { getMsx2PlatformPhysicsFromPlayerEntity, getMsx2DashConfigFromPlayerEntity, getMsx2AirDashConfigFromPlayerEntity, getMsx2GlideConfigFromPlayerEntity, getMsx2WallJumpConfigFromPlayerEntity, getMsx2PowerStompConfigFromPlayerEntity, getMsx2ShootConfigFromPlayerEntity, getMsx2TeleportABConfigFromPlayerEntity, getMsx2SlashConfigFromPlayerEntity, getMsx2GrabConfigFromPlayerEntity, getMsx2HighJumpConfigFromPlayerEntity, getMsx2WallBreakConfigFromPlayerEntity, getMsx2SpinAttackConfigFromPlayerEntity, getMsx2IceSlideConfigFromPlayerEntity, getMsx2CrouchConfigFromPlayerEntity, getMsx2CollectorGemsConfigFromPlayerEntity, getMsx2PerceptionConfigFromPlayerEntity, getMsx2CarryAndThrowConfigFromPlayerEntity, resolveMsx2BitmapKeyboardBinding } from '../../../msx2PlatformPhysics';
+import { getMsx2PlatformPhysicsFromPlayerEntity, getMsx2DashConfigFromPlayerEntity, getMsx2AirDashConfigFromPlayerEntity, getMsx2GlideConfigFromPlayerEntity, getMsx2WallJumpConfigFromPlayerEntity, getMsx2PowerStompConfigFromPlayerEntity, getMsx2ShootConfigFromPlayerEntity, getMsx2TeleportABConfigFromPlayerEntity, getMsx2SlashConfigFromPlayerEntity, getMsx2GrabConfigFromPlayerEntity, getMsx2HighJumpConfigFromPlayerEntity, getMsx2WallBreakConfigFromPlayerEntity, getMsx2SpinAttackConfigFromPlayerEntity, getMsx2IceSlideConfigFromPlayerEntity, getMsx2CrouchConfigFromPlayerEntity, getMsx2DestroyTileConfigFromPlayerEntity, getMsx2CollectorGemsConfigFromPlayerEntity, getMsx2PerceptionConfigFromPlayerEntity, getMsx2CarryAndThrowConfigFromPlayerEntity, resolveMsx2BitmapKeyboardBinding } from '../../../msx2PlatformPhysics';
 import type { Msx2CollectorGemsConfig } from '../../../msx2PlatformPhysics';
 import { buildBitmapPerceptionSystemAsm, bitmapPerceptionWindowNeeded } from './msx2BitmapPerceptionGenerator';
 import {
@@ -144,6 +144,21 @@ import {
   buildBitmapCrouchRuntimeAsm,
   MSX2_BITMAP_CROUCH_RAM_BYTES,
 } from './msx2BitmapCrouchGenerator';
+import {
+  bitmapDestroyTileEnabled,
+  buildBitmapDestroyTileApplyPendingCallAsm,
+  buildBitmapDestroyTileApplyVisibleCallAsm,
+  buildBitmapDestroyTileDataAsm,
+  buildBitmapDestroyTileEquates,
+  buildBitmapDestroyTileGateAsm,
+  buildBitmapDestroyTileInitClearAsm,
+  buildBitmapDestroyTileInitUploadAsm,
+  buildBitmapDestroyTileRuntimeAsm,
+  buildBitmapDestroyTileSatCallAsm,
+  MSX2_BITMAP_DESTROY_DEBRIS_SLOTS,
+  type BitmapDestroyDebrisSprite,
+  type BitmapDestroyTileOptions,
+} from './msx2BitmapDestroyTileGenerator';
 import {
   buildHardwareSpriteLayersForFrame,
   getFirstReferencedMsx2Sprite,
@@ -10177,6 +10192,34 @@ function resolveBitmapBulletSprite(
 }
 
 /**
+ * Resolves the user-authored debris chip sprite for the destroy_tile skill:
+ * `player.render.debrisSpriteAssetId` wins; otherwise the first sprite asset
+ * whose name contains "debris" or "viruta" (case-insensitive). Undefined falls
+ * back to the generator's built-in 3x3 chip.
+ */
+function resolveBitmapDebrisSprite(
+  analysis: ProjectAnalysis,
+  player: Partial<Msx2PlayerDefinition> | undefined,
+): BitmapDestroyDebrisSprite | undefined {
+  const explicitId = String((player?.render as any)?.debrisSpriteAssetId || '').trim();
+  let sprite = explicitId ? resolveMsx2SpriteById(analysis, explicitId) : undefined;
+  if (!sprite) {
+    sprite = (analysis.msx2Sprites || []).find(item => /debris|viruta/i.test(String(item?.name || '')));
+  }
+  if (!sprite) return undefined;
+  const layers = buildHardwareSpriteLayersForFrame(sprite, BITMAP_ROOM_DEFAULT_SPRITE_COLOR, 0)
+    .filter(layer => Array.isArray(layer.pattern) && layer.pattern.length === 32);
+  const primary = layers[0];
+  if (!primary || !Array.isArray(primary.pattern) || primary.pattern.length !== 32) return undefined;
+  const colors = (primary.colors || []).slice(0, 16);
+  while (colors.length < 16) colors.push(BITMAP_ROOM_DEFAULT_SPRITE_COLOR);
+  return {
+    patternBytes: primary.pattern.map(v => v & 0xff),
+    colorBytes: colors.map(v => v & 0xff),
+  };
+}
+
+/**
  * Collect per-room enemy patrol slots for the bitmap-room enemy runtime.
  *
  * Geometry (x/y/bounds/dx/dy/mode) comes from the SAME resolver the SCREEN 4
@@ -11580,6 +11623,20 @@ function generateUnitedFiles(projectName: string, analysis: ProjectAnalysis, con
   }
   const carrySatBase = platformSatBase + platformHardwareSlots * 4;
   const carryColorBase = platformColorBase + platformHardwareSlots * 16;
+  // DESTROY TILE (dig) skill: 4 debris-chip sprites between carry and the
+  // bullets (one shared pattern group). Fixed RAM region at #C2D0 (see the
+  // generator module header); everything is emitted only when the skill is on.
+  const destroyTileConfig = getMsx2DestroyTileConfigFromPlayerEntity(resolveBitmapRoomPlayer(analysis, room));
+  const destroyDebrisSlots = bitmapDestroyTileEnabled(destroyTileConfig) ? MSX2_BITMAP_DESTROY_DEBRIS_SLOTS : 0;
+  const destroyPatternGroup = carryPatternGroupBase + carryPatternGroupCount;
+  if (destroyDebrisSlots > 0 && destroyPatternGroup + 1 > 64) {
+    throw new Error(
+      `SCREEN 5 bitmap-room destroy_tile debris needs sprite pattern group ${destroyPatternGroup}, ` +
+      'but the V9938 sprite pattern table only holds 64 groups. Reduce player/enemy/platform animation or carryable objects.',
+    );
+  }
+  const destroySatBase = carrySatBase + carryAndThrowData.maxSlots * 4;
+  const destroyColorBase = carryColorBase + carryAndThrowData.maxSlots * 16;
   const shootRuntimeOptions: BitmapShootRuntimeOptions = {
     playerLayerCount: spriteTables.layerCount,
     bulletPatternNumber,
@@ -11592,6 +11649,7 @@ function generateUnitedFiles(projectName: string, analysis: ProjectAnalysis, con
     enemySlotCount: enemyData.maxSlots,
     platformSlotCount: platformHardwareSlots,
     carrySlotCount: carryAndThrowData.maxSlots,
+    destroySlotCount: destroyDebrisSlots,
   };
   const shootBulletInitUpload = buildBitmapBulletInitUploadAsm(shootConfig, shootRuntimeOptions);
   const shootBulletSatCall = buildBitmapBulletSatCallAsm(shootConfig);
@@ -11666,6 +11724,47 @@ function generateUnitedFiles(projectName: string, analysis: ProjectAnalysis, con
     crouching: stateAnimIds['crouching'],
     sliding: stateAnimIds['sliding'],
   });
+  // DESTROY TILE (dig) skill pieces. The per-room destructible masks come from
+  // the authoritative tileGrid + the atlas entries' "Destructible" checkbox;
+  // the dissolve colour is each room's background colour duplicated into both
+  // HMMV nibbles. RAM is the fixed #C2D0 region (module header documents it).
+  const destroyTileOptions: BitmapDestroyTileOptions = {
+    ramBase: 0xC2D0,
+    hitbox: playerHitbox,
+    digAnimId: stateAnimIds['digging'],
+    debrisPatternNumber: destroyPatternGroup * 4,
+    debrisSatBase: destroySatBase,
+    debrisColorBase: destroyColorBase,
+    gameYOffset: BITMAP_ROOM_GAME_Y_OFFSET,
+    destructibleMasks: rooms.map(roomItem => {
+      const entries = roomItem.atlas?.entries || [];
+      const grid = buildRoomTileIndexGrid(roomItem);
+      const mask = Array(COLLISION_COLS * COLLISION_ROWS / 8).fill(0);
+      for (let y = 0; y < COLLISION_ROWS; y++) {
+        for (let x = 0; x < COLLISION_COLS; x++) {
+          const value = grid[y][x];
+          if (!value || entries[value - 1]?.destructible !== true) continue;
+          const cell = y * COLLISION_COLS + x;
+          mask[cell >> 3] |= 1 << (cell & 7);
+        }
+      }
+      return mask;
+    }),
+    bgColorBytes: rooms.map(roomItem => {
+      const bg = clampByte(roomItem.backgroundColor, 0) & 0x0f;
+      return (bg << 4) | bg;
+    }),
+  };
+  const destroyDebrisSprite = resolveBitmapDebrisSprite(analysis, resolveBitmapRoomPlayer(analysis, room));
+  const destroyTileEquates = buildBitmapDestroyTileEquates(destroyTileConfig, destroyTileOptions);
+  const destroyTileInitClear = buildBitmapDestroyTileInitClearAsm(destroyTileConfig);
+  const destroyTileGate = buildBitmapDestroyTileGateAsm(destroyTileConfig);
+  const destroyTileSatCall = buildBitmapDestroyTileSatCallAsm(destroyTileConfig);
+  const destroyTileApplyVisibleCall = buildBitmapDestroyTileApplyVisibleCallAsm(destroyTileConfig);
+  const destroyTileApplyPendingCall = buildBitmapDestroyTileApplyPendingCallAsm(destroyTileConfig);
+  const destroyTileInitUpload = buildBitmapDestroyTileInitUploadAsm(destroyTileConfig, destroyTileOptions);
+  const destroyTileRuntime = buildBitmapDestroyTileRuntimeAsm(destroyTileConfig, destroyTileOptions);
+  const destroyTileDataAsm = buildBitmapDestroyTileDataAsm(destroyTileConfig, destroyTileOptions, destroyDebrisSprite);
   // Linked MSX2 HUD asset dynamic widgets: RAM follows crouch (the last skill in
   // the chain). Per widget: dirty-flag (1 byte, or 2 for wide 16-bit counters so a
   // high-byte-only change is detected) + value byte(s) for bindings without a real
@@ -11803,7 +11902,7 @@ function generateUnitedFiles(projectName: string, analysis: ProjectAnalysis, con
     hudLinkedRamCursor,
     dialogueVramBaseRow,
     buildRleUploadAsm(dialogueRleChunks, isKonamiMegaRom),
-    `${keyDoorSystem.initialDrawCall}${gemSystem.initialDrawCall}${jumperSystem.initialDrawCall}${wallJumperSystem.initialDrawCall}`,
+    `${keyDoorSystem.initialDrawCall}${gemSystem.initialDrawCall}${jumperSystem.initialDrawCall}${wallJumperSystem.initialDrawCall}${destroyTileApplyVisibleCall}`,
     isKonamiMegaRom
   );
   hudLinkedRamCursor += dialogueSystem.ramBytes;
@@ -11876,7 +11975,7 @@ function generateUnitedFiles(projectName: string, analysis: ProjectAnalysis, con
     collectibleCounter: gemCounterRam,
     keyCountAvailable: keyDoorSystem.ramBytes > 0,
     bankedRoomData: isKonamiMegaRom,
-    repaintOverlaysAsm: `${keyDoorSystem.initialDrawCall}${gemSystem.initialDrawCall}${jumperSystem.initialDrawCall}${wallJumperSystem.initialDrawCall}`,
+    repaintOverlaysAsm: `${keyDoorSystem.initialDrawCall}${gemSystem.initialDrawCall}${jumperSystem.initialDrawCall}${wallJumperSystem.initialDrawCall}${destroyTileApplyVisibleCall}`,
   });
   hudLinkedRamCursor += perceptionSystem.ramBytes;
   if ((linkedHudDynamicSources.length || keyDoorSystem.enabled || gemSystem.enabled || perceptionSystem.enabled || jumperSystem.enabled || wallJumperSystem.enabled || dialogueSystem.enabled || enemySystem.enabled || platformSystem.enabled || carryAndThrowSystem.enabled) && hudLinkedRamCursor > HUD_LINKED_RAM_CEILING) {
@@ -11944,7 +12043,7 @@ ${hudDec3BufferAddress !== undefined ? `hud_dec3_buffer EQU ${hexWord(hudDec3Buf
     gravityHookAsm: gravityHooks,
     landClearAsm: landClearHooks,
     leaveGroundAsm: leaveGroundHooks,
-  }, foregroundContext, true /* enableBlink: bitmap backend always renders i-frame flicker */, keyDoorSystem.enabled, `${keyDoorSystem.pendingPageDrawCall}${gemSystem.pendingPageDrawCall}${jumperSystem.pendingPageDrawCall}${wallJumperSystem.pendingPageDrawCall}`, keyDoorSystem.solidProbeCallAsm, `${enemySystem.loadCallAsm}${platformSystem.loadCallAsm}${carryAndThrowSystem.loadCallAsm}`);
+  }, foregroundContext, true /* enableBlink: bitmap backend always renders i-frame flicker */, keyDoorSystem.enabled, `${keyDoorSystem.pendingPageDrawCall}${gemSystem.pendingPageDrawCall}${jumperSystem.pendingPageDrawCall}${wallJumperSystem.pendingPageDrawCall}${destroyTileApplyPendingCall}`, keyDoorSystem.solidProbeCallAsm, `${enemySystem.loadCallAsm}${platformSystem.loadCallAsm}${carryAndThrowSystem.loadCallAsm}`);
   // Foreground sprite load routine + its per-room dispatch/data tables (only when
   // some room actually defines foreground tiles).
   const foregroundLoadRoutineAsm = foregroundContext ? buildBitmapLoadForegroundSpritesAsm(foregroundContext) : '';
@@ -12018,7 +12117,7 @@ ${hudDec3BufferAddress !== undefined ? `hud_dec3_buffer EQU ${hexWord(hudDec3Buf
     ; be missing on page 0 and appear only on the never-wiped page 1 ("gem icon on
     ; alternate rooms"). Harmless on the plain boot path (idempotent re-upload).
     call init_bitmap_hud_band
-${keyDoorSystem.initialDrawCall}${gemSystem.initialDrawCall}${jumperSystem.initialDrawCall}${wallJumperSystem.initialDrawCall}
+${keyDoorSystem.initialDrawCall}${gemSystem.initialDrawCall}${jumperSystem.initialDrawCall}${wallJumperSystem.initialDrawCall}${destroyTileApplyVisibleCall}
 ${foregroundLoadCallAsm}${enemySystem.loadCallAsm}${platformSystem.loadCallAsm}${carryAndThrowSystem.loadCallAsm}    ; Place the player at the room spawn point.
     ld a, ${spawn.y}
     ld (player_y), a
@@ -12059,7 +12158,7 @@ ${hasStateAnimations ? `    xor a
     ld (player_anim_abs_frame), a
     dec a
     ld (player_anim_state_prev), a    ; #FF forces a clean clip reset on frame 1
-` : ''}${dashInitClear}${doubleJumpInitClear}${coyoteBufferInitClear}${airDashInitClear}${glideInitClear}${wallJumpInitClear}${powerStompInitClear}${shootInitClear}${teleportInitClear}${slashInitClear}${grabInitClear}${highJumpInitClear}${wallBreakInitClear}${spinAttackInitClear}${iceSlideInitClear}${crouchInitClear}`;
+` : ''}${dashInitClear}${doubleJumpInitClear}${coyoteBufferInitClear}${airDashInitClear}${glideInitClear}${wallJumpInitClear}${powerStompInitClear}${shootInitClear}${teleportInitClear}${slashInitClear}${grabInitClear}${highJumpInitClear}${wallBreakInitClear}${spinAttackInitClear}${iceSlideInitClear}${crouchInitClear}${destroyTileInitClear}`;
 
   // Game Flow dispatcher (compile-time, bitmap backend). When a Game Flow graph
   // with a WorldLink exists, the ROM boots into the dispatcher (bitmap_gf_entry)
@@ -12189,7 +12288,7 @@ ${crouchEquates}
 ; Used by surface skills such as ice_slide. Kept away from the compact player
 ; state/skill chain so future optional skills do not overlap it.
 bitmap_room_behavior_map EQU #C200
-${deadlySystem.equates}${heartsHud.equates}${linkedHudEquates}${enemySystem.equates}${platformSystem.equates}${carryAndThrowSystem.equates}    org #4000
+${deadlySystem.equates}${heartsHud.equates}${linkedHudEquates}${enemySystem.equates}${platformSystem.equates}${carryAndThrowSystem.equates}${destroyTileEquates}    org #4000
 
     db "AB"
     dw init_rom
@@ -12208,7 +12307,7 @@ ${intro.initCallAsm}    call load_screen5_bitmap_palette
     call init_bitmap_hud_band
     call upload_tileset_atlas
     call init_hardware_sprite_tables
-${dialogueSystem.uploadCallAsm}${shootBulletInitUpload}${gameFlowEnabled ? '    ; Game Flow graph present: the dispatcher (bitmap_gf_entry) runs the shared\n    ; boot-init sequence (bitmapBootInitAsm) inside its WorldLink node, so the\n    ; inline copy below is skipped. Both paths use the SAME init string, which\n    ; resets bitmap_composition_state + the composition vars, loads enemies/\n    ; platforms, restores R#15=S#0 and clears the skill state. (Skipping the init\n    ; here previously left those uninitialised: a garbage composition state armed\n    ; a bogus room transition every few frames -> periodic player reposition, and\n    ; made the deadly/enemy damage systems ret-early -> spikes cost no hearts.)\n    jp bitmap_gf_entry\n' : bitmapBootInitAsm}${gameFlowEntryAsm}bitmap_enter_game_loop:
+${dialogueSystem.uploadCallAsm}${shootBulletInitUpload}${destroyTileInitUpload}${gameFlowEnabled ? '    ; Game Flow graph present: the dispatcher (bitmap_gf_entry) runs the shared\n    ; boot-init sequence (bitmapBootInitAsm) inside its WorldLink node, so the\n    ; inline copy below is skipped. Both paths use the SAME init string, which\n    ; resets bitmap_composition_state + the composition vars, loads enemies/\n    ; platforms, restores R#15=S#0 and clears the skill state. (Skipping the init\n    ; here previously left those uninitialised: a garbage composition state armed\n    ; a bogus room transition every few frames -> periodic player reposition, and\n    ; made the deadly/enemy damage systems ret-early -> spikes cost no hearts.)\n    jp bitmap_gf_entry\n' : bitmapBootInitAsm}${gameFlowEntryAsm}bitmap_enter_game_loop:
     ; Game Flow exit gate: when the deadly/enemy damage system arms
     ; bitmap_game_over_flag (last life spent), leave the gameplay loop. With a
     ; Game Flow graph, ret returns to the dispatcher (which follows the WorldLink
@@ -12222,9 +12321,9 @@ ${dialogueSystem.uploadCallAsm}${shootBulletInitUpload}${gameFlowEnabled ? '    
     jp c, .skip_player_movement
 ${platformSystem.updateCallAsm}${dialogueSystem.mainLoopGateAsm}${perceptionSystem.inventoryGateAsm}${airDashGate}    ; Normal platform movement/gravity runs only when no transition/air_dash consumed this frame.
     call update_player_movement
-${dashGate}${shootGate}${teleportGate}${slashGate}${grabGate}${wallBreakGate}${spinAttackGate}${platformSystem.detectCallAsm}.skip_player_movement:
+${dashGate}${shootGate}${teleportGate}${slashGate}${grabGate}${wallBreakGate}${spinAttackGate}${destroyTileGate}${platformSystem.detectCallAsm}.skip_player_movement:
 ${perceptionSystem.mainLoopCall}${playerAnimationUpdateCall}${playerColorsUpdateCall}${powerStompMainLoopCall}${deadlySystem.mainLoopCall}${heartsHud.mainLoopCall}${linkedHudMainLoopCall}${hudSeparatorRestore.mainLoopCall}${enemySystem.updateCallAsm}${carryAndThrowSystem.updateCallAsm}${keyDoorSystem.pressureButtonCall}    call bitmap_update_sprite_sat
-${enemySystem.satCallAsm}${platformSystem.satCallAsm}${carryAndThrowSystem.satCallAsm}${shootBulletSatCall}    jp .bitmap_main_loop
+${enemySystem.satCallAsm}${platformSystem.satCallAsm}${carryAndThrowSystem.satCallAsm}${destroyTileSatCall}${shootBulletSatCall}    jp .bitmap_main_loop
 ${intro.routinesAsm}
 ${runtimeAsm}
 ${dashRuntime}
@@ -12243,6 +12342,7 @@ ${wallBreakRuntime}
 ${spinAttackRuntime}
 ${iceSlideRuntime}
 ${crouchRuntime}
+${destroyTileRuntime}
 ${deadlySystem.routineAsm}
 ${heartsHud.routinesAsm}
 ${linkedHudRoutinesAsm}
@@ -12282,7 +12382,7 @@ ${roomTransitionTableAsm}
 ${roomSpawnTableAsm}
 ${keyDoorSystem.dataAsm}
 ${gemSystem.dataAsm}
-${perceptionSystem.dataAsm}
+${destroyTileDataAsm}${perceptionSystem.dataAsm}
 ${jumperSystem.dataAsm}
 ${wallJumperSystem.dataAsm}
 ${dialogueSystem.dataAsm}${dialogueGfxDataAsm}

--- a/utils/msxGenerator/generators/msx2/msx2Screen5BitmapRoomGenerator.ts
+++ b/utils/msxGenerator/generators/msx2/msx2Screen5BitmapRoomGenerator.ts
@@ -11739,11 +11739,28 @@ function generateUnitedFiles(projectName: string, analysis: ProjectAnalysis, con
     destructibleMasks: rooms.map(roomItem => {
       const entries = roomItem.atlas?.entries || [];
       const grid = buildRoomTileIndexGrid(roomItem);
+      const collision = roomItem.collision || [];
       const mask = Array(COLLISION_COLS * COLLISION_ROWS / 8).fill(0);
+      // Per-cell destructible bit (0x80 in the collision grid) is the source of truth:
+      // it lets the SAME visual tile be diggable in one cell and only-solid in another
+      // (secret paths). The editor stamps this bit when painting a "Destructible" atlas
+      // tile and lets the Select tool toggle it per cell.
+      let anyCellBit = false;
+      for (let y = 0; y < COLLISION_ROWS && !anyCellBit; y++) {
+        for (let x = 0; x < COLLISION_COLS; x++) {
+          if (((collision[y]?.[x] ?? 0) & 0x80) !== 0) { anyCellBit = true; break; }
+        }
+      }
       for (let y = 0; y < COLLISION_ROWS; y++) {
         for (let x = 0; x < COLLISION_COLS; x++) {
           const value = grid[y][x];
-          if (!value || entries[value - 1]?.destructible !== true) continue;
+          // Prefer the authored per-cell bit; fall back to the atlas flag only for rooms
+          // saved before the per-cell bit existed (no 0x80 anywhere) so old projects keep
+          // their masks unchanged.
+          const destructible = anyCellBit
+            ? ((collision[y]?.[x] ?? 0) & 0x80) !== 0
+            : (!!value && entries[value - 1]?.destructible === true);
+          if (!destructible) continue;
           const cell = y * COLLISION_COLS + x;
           mask[cell >> 3] |= 1 << (cell & 7);
         }

--- a/utils/msxGenerator/skills/data/destroy_tile.json
+++ b/utils/msxGenerator/skills/data/destroy_tile.json
@@ -1,0 +1,68 @@
+{
+  "id": "destroy_tile",
+  "label": "Destroy Tile (dig)",
+  "description": "Pick at the wall ahead to dissolve destructible tiles, Terraria style",
+  "required": false,
+  "cycles": 220,
+  "controlIcon": "attack",
+  "addsStates": ["digging"],
+  "icon": "⛏️",
+  "category": "utility",
+  "supportedBackends": ["msx2-screen4-bitmap-room"],
+  "parameters": [
+    {
+      "key": "digKey",
+      "label": "Dig key (0=SPACE 1=B 2=N 3=Z 4=X 5=M)",
+      "type": "number",
+      "default": 1,
+      "min": 0,
+      "max": 5,
+      "step": 1,
+      "help": "Keyboard key that swings the pick: 0=SPACE, 1=B, 2=N, 3=Z, 4=X, 5=M. Avoid keys used by other active skills (M=dash, N=shoot, R=wall_break)."
+    },
+    {
+      "key": "hitsPerTile",
+      "label": "Hits to destroy a tile",
+      "type": "number",
+      "default": 3,
+      "min": 1,
+      "max": 8,
+      "step": 1,
+      "help": "How many pick swings a destructible 16x16 tile takes before it dissolves."
+    },
+    {
+      "key": "digCooldown",
+      "label": "Swing cooldown (frames)",
+      "type": "number",
+      "default": 12,
+      "min": 4,
+      "max": 60,
+      "step": 1,
+      "help": "Frames between pick swings. 12 = 5 swings/second at 60 fps."
+    },
+    {
+      "key": "requireKeyRelease",
+      "label": "Require key release between swings",
+      "type": "boolean",
+      "default": false,
+      "help": "If true, the key must be released between swings. If false, holding the key keeps digging at the cooldown rate."
+    },
+    {
+      "key": "destroyedLimit",
+      "label": "Max destroyed tiles remembered",
+      "type": "number",
+      "default": 64,
+      "min": 16,
+      "max": 128,
+      "step": 16,
+      "help": "Capacity of the persistence list (2 bytes of RAM per tile). Tiles destroyed beyond this limit reappear when re-entering the screen."
+    },
+    {
+      "key": "digSound",
+      "label": "Pick hit sound (PSG)",
+      "type": "boolean",
+      "default": true,
+      "help": "Fire-and-forget PSG thud on every pick hit."
+    }
+  ]
+}

--- a/utils/msxGenerator/skills/handlers/index.ts
+++ b/utils/msxGenerator/skills/handlers/index.ts
@@ -342,6 +342,92 @@ export const wallBreak: SkillDef = {
   transitions: [],
 };
 
+export const destroyTileParameters: SkillParameterDef[] = [
+  {
+    key: 'digKey',
+    label: 'Dig key (0=SPACE 1=B 2=N 3=Z 4=X 5=M)',
+    type: 'number',
+    default: 1,
+    min: 0,
+    max: 5,
+    step: 1,
+    help: 'Keyboard key that swings the pick: 0=SPACE, 1=B, 2=N, 3=Z, 4=X, 5=M. Avoid keys used by other active skills (M=dash, N=shoot, R=wall_break).',
+  },
+  {
+    key: 'hitsPerTile',
+    label: 'Hits to destroy a tile',
+    type: 'number',
+    default: 3,
+    min: 1,
+    max: 8,
+    step: 1,
+    help: 'How many pick swings a destructible 16x16 tile takes before it dissolves.',
+  },
+  {
+    key: 'digCooldown',
+    label: 'Swing cooldown (frames)',
+    type: 'number',
+    default: 12,
+    min: 4,
+    max: 60,
+    step: 1,
+    help: 'Frames between pick swings. 12 = 5 swings/second at 60 fps.',
+  },
+  {
+    key: 'requireKeyRelease',
+    label: 'Require key release between swings',
+    type: 'boolean',
+    default: false,
+    help: 'If true, the key must be released between swings. If false, holding the key keeps digging at the cooldown rate.',
+  },
+  {
+    key: 'destroyedLimit',
+    label: 'Max destroyed tiles remembered',
+    type: 'number',
+    default: 64,
+    min: 16,
+    max: 128,
+    step: 16,
+    help: 'Capacity of the persistence list (2 bytes of RAM per tile). Tiles destroyed beyond this limit reappear when re-entering the screen.',
+  },
+  {
+    key: 'digSound',
+    label: 'Pick hit sound (PSG)',
+    type: 'boolean',
+    default: true,
+    help: 'Fire-and-forget PSG thud on every pick hit.',
+  },
+];
+
+/**
+ * Terraria-style digging for SCREEN 5 bitmap rooms: pick at the wall ahead
+ * (facing direction, top body cell first, then the bottom one), spawn debris
+ * chips (hardware sprites), dissolve the 16x16 bitmap tile to the room
+ * background colour and flip the collision cell to no-solid. Destroyed tiles
+ * are remembered per room (destroyedLimit entries) and re-applied every time
+ * the room is composed again, so holes are permanent within the play session.
+ * Only atlas tiles marked "Destructible" in the SCREEN 5 screen editor react.
+ * The optional 'digging' row of the Player Animations table selects a
+ * dedicated pick-swing sprite; the debris chip sprite comes from
+ * `player.render.debrisSpriteAssetId` or a sprite asset literally named
+ * "debris" (a built-in 4-pixel chip is used as fallback).
+ */
+export const destroyTile: SkillDef = {
+  id: 'destroy_tile',
+  label: 'Destroy tile (dig ahead)',
+  required: false,
+  supportedBackends: ['msx2-screen4-bitmap-room'],
+  cycles: 220,
+  controlIcon: 'attack',
+  addsStates: ['digging'],
+  transitions: [
+    { from: ['grounded', 'running', 'jumping', 'falling'], to: 'digging', condition: 'dig_key_pressed AND destructible_tile_ahead' },
+    { from: ['digging'], to: 'grounded', condition: 'dig_anim_done AND grounded' },
+    { from: ['digging'], to: 'falling', condition: 'dig_anim_done AND NOT grounded' },
+  ],
+  parameters: destroyTileParameters,
+};
+
 export const grabParameters: SkillParameterDef[] = [
   { key: 'slideSpeed', label: 'Wall slide speed (px/frame)', type: 'number', default: 1, min: 0, max: 4, step: 1, help: 'Max fall speed while clinging to a wall. 0 = frozen on wall.' },
 ];

--- a/utils/msxGenerator/skills/index.ts
+++ b/utils/msxGenerator/skills/index.ts
@@ -6,7 +6,7 @@ import {
   wallJump, airDash, chargeAttack, glide, spinAttack,
   parry, crouch, climb, highJump, collectorGems, collectorItems,
   pushWall, pushDoor, carryObject, teleportAB, carryAndThrow,
-  powerStomp, iceSlide, perception,
+  powerStomp, iceSlide, perception, destroyTile,
 } from './handlers/index';
 
 for (const skill of [
@@ -16,7 +16,7 @@ for (const skill of [
   wallJump, airDash, chargeAttack, glide, spinAttack,
   parry, crouch, climb, highJump, collectorGems, collectorItems,
   pushWall, pushDoor, carryObject, teleportAB, carryAndThrow,
-  powerStomp, iceSlide, perception,
+  powerStomp, iceSlide, perception, destroyTile,
 ]) {
   registerSkill(skill);
 }
@@ -33,5 +33,5 @@ export {
   wallJump, airDash, chargeAttack, glide, spinAttack,
   parry, crouch, climb, highJump, collectorGems, collectorItems,
   pushWall, pushDoor, carryObject, teleportAB, carryAndThrow,
-  powerStomp, iceSlide, perception,
+  powerStomp, iceSlide, perception, destroyTile,
 } from './handlers/index';


### PR DESCRIPTION
## Summary

Implements the `destroy_tile` skill (Terraria-style wall breaking) for MSX2 SCREEN 5 bitmap rooms:

- **Per-cell destructibility** (secret paths): the 0x80 bit in `room.collision` determines which cells can be dug, allowing the same visual tile to be breakable in one cell and solid-only in another.
- **Select tool**: new tool to pick individual cells for property editing without painting.
- **Debris animation**: configurable debris sprite and pick-swing animation via custom `DestroyTileDialog`.
- **Persistence**: dug cells are tracked and re-applied on room composition.
- **Full ASM runtime**: multi-hit detection, HMMV dissolve, 4 debris chips with gravity, configurable dig key/cooldown/sound.

## Test plan

- ✅ End-to-end: fixture with atlas-level destructible → mask byte-identical to pre-change.
- ✅ Per-cell override: fixture with 0x80 on 1 cell + atlas destructible → mask marks only that cell (secret path proof).
- ✅ Both compile with glass.jar.
- ✅ No regression on existing destroy_tile smoke tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)